### PR TITLE
Added InputSelect component

### DIFF
--- a/src/app/components/ui/InputSelect.tsx
+++ b/src/app/components/ui/InputSelect.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import {
+  Listbox,
+  ListboxButton,
+  ListboxOptions,
+  ListboxOption,
+  Transition,
+} from '@headlessui/react';
+import clsx from 'clsx';
+import React, { Fragment, useId } from 'react';
+
+import { InputHeader } from './InputHeader';
+
+export type InputSelectVariants = 'primary' | 'secondary' | 'danger';
+export type InputSelectSizes = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+export type InputSelectOption<TValue> = {
+  value: TValue;
+  label: React.ReactNode;
+  description?: React.ReactNode;
+  key?: string | number;
+  disabled?: boolean;
+};
+
+export interface InputSelectProps<TValue> {
+  variant?: InputSelectVariants;
+  size?: InputSelectSizes;
+  fullWidth?: boolean;
+  error?: boolean | string;
+  label?: React.ReactNode;
+  description?: React.ReactNode;
+  required?: boolean;
+  id?: string;
+  value: TValue;
+  onChange: (value: TValue) => void;
+  options: Array<InputSelectOption<TValue>>;
+  placeholder?: React.ReactNode;
+  disabled?: boolean;
+  renderValue?: (option: InputSelectOption<TValue>) => React.ReactNode;
+  by?: (a: TValue, b: TValue) => boolean;
+  className?: string;
+}
+
+const baseButtonStyle =
+  'relative w-full text-left text-zinc-100 shadow-inner shadow-white/5 transition focus:outline-none disabled:cursor-not-allowed';
+
+const variantStyles: Record<InputSelectVariants, string> = {
+  primary: 'rounded-2xl border-white/10 bg-white/5',
+  secondary: 'rounded-lg border-white/10 bg-zinc-900',
+  danger: 'rounded-2xl border-rose-400/60 bg-rose-500/10',
+};
+
+const variantFocusStyles: Record<InputSelectVariants, string> = {
+  primary: 'focus:border-indigo-400/60 focus:ring-2 focus:ring-indigo-500/40',
+  secondary: 'focus:border-fuchsia-500/50',
+  danger: 'focus:border-rose-500/80 focus:ring-2 focus:ring-rose-500/40',
+};
+
+const variantHoverStyles: Record<InputSelectVariants, string> = {
+  primary: 'hover:border-white/20',
+  secondary: 'hover:border-white/15',
+  danger: 'hover:border-rose-400/70',
+};
+
+const sizeStyles: Record<InputSelectSizes, string> = {
+  xs: 'text-xs px-2 py-1.5',
+  sm: 'text-sm px-3 py-2',
+  md: 'text-sm px-4 py-3',
+  lg: 'text-base px-6 py-3',
+  xl: 'text-lg px-8 py-4',
+};
+
+const disabledStyle = 'opacity-50';
+
+const defaultErrorStyle = 'border-rose-400/60 focus:border-rose-400/80';
+const variantErrorStyles: Record<InputSelectVariants, string> = {
+  primary: defaultErrorStyle,
+  secondary: defaultErrorStyle,
+  danger: 'border-rose-500/80 focus:border-rose-500/90',
+};
+
+const listBaseStyle =
+  'absolute z-10 mt-2 max-h-60 w-full overflow-auto border bg-zinc-900/95 p-2 text-sm shadow-lg focus:outline-none';
+
+const listVariantStyles: Record<InputSelectVariants, string> = {
+  primary: 'rounded-2xl border-white/10 shadow-indigo-500/20',
+  secondary: 'rounded-lg border-white/10 shadow-fuchsia-500/20',
+  danger: 'rounded-2xl border-rose-400/40 shadow-rose-500/20',
+};
+
+export function InputSelect<TValue>({
+  variant = 'primary',
+  size = 'md',
+  fullWidth = false,
+  error,
+  label,
+  description,
+  required,
+  id,
+  value,
+  onChange,
+  options,
+  placeholder,
+  disabled,
+  renderValue,
+  by,
+  className,
+}: InputSelectProps<TValue>) {
+  const generatedId = useId();
+  const selectId = id || generatedId;
+  const errorMessage = typeof error === 'string' ? error : undefined;
+
+  const activeOption = options.find((option) =>
+    by ? by(option.value, value) : option.value === value,
+  );
+
+  const hasHeader = !!label || !!required;
+
+  return (
+    <div className="space-y-2">
+      <div className={clsx(fullWidth ? 'w-full' : 'inline-block')}>
+        {hasHeader && (
+          <InputHeader htmlFor={selectId} label={label} required={required} />
+        )}
+
+        <div className="relative mt-1">
+          <Listbox
+            value={value}
+            onChange={onChange}
+            disabled={disabled}
+            by={by}
+          >
+            <ListboxButton
+              id={selectId}
+              className={clsx(
+                baseButtonStyle,
+                'border',
+                variantStyles[variant],
+                sizeStyles[size],
+                disabled && disabledStyle,
+                !!error && variantErrorStyles[variant],
+                !disabled && !error && variantFocusStyles[variant],
+                !disabled && !error && variantHoverStyles[variant],
+                className,
+              )}
+            >
+              <span className="block truncate">
+                {activeOption
+                  ? renderValue
+                    ? renderValue(activeOption)
+                    : activeOption.label
+                  : (placeholder ?? 'Select...')}
+              </span>
+              <span className="pointer-events-none absolute inset-y-0 right-4 flex items-center text-zinc-500">
+                ▾
+              </span>
+            </ListboxButton>
+            <Transition
+              as={Fragment}
+              leave="transition ease-in duration-100"
+              leaveFrom="opacity-100"
+              leaveTo="opacity-0"
+            >
+              <ListboxOptions
+                className={clsx(listBaseStyle, listVariantStyles[variant])}
+              >
+                {options.map((option, index) => (
+                  <ListboxOption
+                    key={option.key ?? index}
+                    value={option.value}
+                    disabled={option.disabled}
+                    className={({ focus, selected, disabled: isDisabled }) =>
+                      clsx(
+                        'cursor-pointer rounded-xl px-3 py-2 transition',
+                        selected && 'bg-indigo-500/20 text-white',
+                        focus && !selected && 'bg-indigo-500/10 text-zinc-100',
+                        isDisabled && 'cursor-not-allowed opacity-50',
+                      )
+                    }
+                  >
+                    <div className="flex flex-col">
+                      <span className="font-medium">{option.label}</span>
+                      {option.description ? (
+                        <span className="text-xs text-zinc-500">
+                          {option.description}
+                        </span>
+                      ) : null}
+                    </div>
+                  </ListboxOption>
+                ))}
+              </ListboxOptions>
+            </Transition>
+          </Listbox>
+        </div>
+      </div>
+
+      {description && <p className="text-xs text-zinc-500">{description}</p>}
+
+      {errorMessage && (
+        <p className="text-xs font-medium text-rose-400">{errorMessage}</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/showcase/inputselect/page.tsx
+++ b/src/app/showcase/inputselect/page.tsx
@@ -1,0 +1,319 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  InputSelect,
+  type InputSelectOption,
+} from '@pointwise/app/components/ui/InputSelect';
+import BackgroundGlow from '@pointwise/app/components/general/BackgroundGlow';
+
+const SIMPLE_OPTIONS: InputSelectOption<string>[] = [
+  { value: 'option1', label: 'Option 1' },
+  { value: 'option2', label: 'Option 2' },
+  { value: 'option3', label: 'Option 3' },
+];
+
+const CATEGORY_OPTIONS: InputSelectOption<string>[] = [
+  { value: 'work', label: 'Work' },
+  { value: 'personal', label: 'Personal' },
+  { value: 'health', label: 'Health' },
+  { value: 'fitness', label: 'Fitness' },
+  { value: 'learning', label: 'Learning' },
+];
+
+const OPTIONS_WITH_DESCRIPTIONS: InputSelectOption<string>[] = [
+  {
+    value: 'daily',
+    label: 'Daily',
+    description: 'Repeats every day',
+  },
+  {
+    value: 'weekly',
+    label: 'Weekly',
+    description: 'Repeats once per week',
+  },
+  {
+    value: 'monthly',
+    label: 'Monthly',
+    description: 'Repeats once per month',
+  },
+];
+
+const PRIORITY_OPTIONS: InputSelectOption<'low' | 'medium' | 'high'>[] = [
+  { value: 'low', label: 'Low Priority' },
+  { value: 'medium', label: 'Medium Priority' },
+  { value: 'high', label: 'High Priority' },
+];
+
+export default function InputSelectShowcasePage() {
+  const [simpleValue, setSimpleValue] = useState<string>('');
+  const [categoryValue, setCategoryValue] = useState<string>('');
+  const [recurrenceValue, setRecurrenceValue] = useState<string>('');
+  const [priorityValue, setPriorityValue] = useState<'low' | 'medium' | 'high'>(
+    'low',
+  );
+  const [primaryValue, setPrimaryValue] = useState<string>('');
+  const [secondaryValue, setSecondaryValue] = useState<string>('');
+  const [dangerValue, setDangerValue] = useState<string>('');
+  const [xsValue, setXsValue] = useState<string>('');
+  const [smValue, setSmValue] = useState<string>('');
+  const [mdValue, setMdValue] = useState<string>('');
+  const [lgValue, setLgValue] = useState<string>('');
+  const [xlValue, setXlValue] = useState<string>('');
+  const [errorValue, setErrorValue] = useState<string>('');
+  const [disabledValue, setDisabledValue] = useState<string>('option1');
+  const [requiredValue, setRequiredValue] = useState<string>('');
+
+  return (
+    <div className="relative min-h-screen bg-zinc-950 text-zinc-100 overflow-hidden">
+      <BackgroundGlow />
+      <div className="relative z-10 max-w-4xl mx-auto px-6 py-12 space-y-12">
+        <div>
+          <h1 className="text-3xl font-bold mb-2">
+            InputSelect Component Showcase
+          </h1>
+          <p className="text-sm text-zinc-400">
+            Display of InputSelect component variants, sizes, and use cases
+          </p>
+        </div>
+
+        {/* Variants */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">Variants</h2>
+          <p className="text-xs text-zinc-500">
+            Different visual styles for different contexts
+          </p>
+          <div className="space-y-4 max-w-md">
+            <InputSelect
+              variant="primary"
+              label="Primary Variant"
+              value={primaryValue}
+              onChange={setPrimaryValue}
+              options={SIMPLE_OPTIONS}
+              placeholder="Select an option..."
+            />
+            <InputSelect
+              variant="secondary"
+              label="Secondary Variant"
+              value={secondaryValue}
+              onChange={setSecondaryValue}
+              options={SIMPLE_OPTIONS}
+              placeholder="Select an option..."
+            />
+            <InputSelect
+              variant="danger"
+              label="Danger Variant"
+              value={dangerValue}
+              onChange={setDangerValue}
+              options={SIMPLE_OPTIONS}
+              placeholder="Select an option..."
+            />
+          </div>
+        </section>
+
+        {/* Sizes */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">Sizes</h2>
+          <p className="text-xs text-zinc-500">
+            Size variants matching Input/InputArea component system
+          </p>
+          <div className="space-y-4 max-w-md">
+            <InputSelect
+              size="xs"
+              label="Extra Small (xs)"
+              value={xsValue}
+              onChange={setXsValue}
+              options={SIMPLE_OPTIONS}
+            />
+            <InputSelect
+              size="sm"
+              label="Small (sm)"
+              value={smValue}
+              onChange={setSmValue}
+              options={SIMPLE_OPTIONS}
+            />
+            <InputSelect
+              size="md"
+              label="Medium (md) - default"
+              value={mdValue}
+              onChange={setMdValue}
+              options={SIMPLE_OPTIONS}
+            />
+            <InputSelect
+              size="lg"
+              label="Large (lg)"
+              value={lgValue}
+              onChange={setLgValue}
+              options={SIMPLE_OPTIONS}
+            />
+            <InputSelect
+              size="xl"
+              label="Extra Large (xl)"
+              value={xlValue}
+              onChange={setXlValue}
+              options={SIMPLE_OPTIONS}
+            />
+          </div>
+        </section>
+
+        {/* Variant × Size Matrix */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">
+            Variant × Size Matrix
+          </h2>
+          <div className="space-y-6">
+            {(['xs', 'sm', 'md', 'lg', 'xl'] as const).map((size) => (
+              <div key={size} className="space-y-2">
+                <h3 className="text-sm font-medium text-zinc-400 uppercase tracking-wide">
+                  Size: {size}
+                </h3>
+                <div className="flex flex-wrap gap-4 max-w-2xl">
+                  <InputSelect
+                    variant="primary"
+                    size={size}
+                    value={simpleValue}
+                    onChange={setSimpleValue}
+                    options={SIMPLE_OPTIONS}
+                    placeholder="Primary"
+                  />
+                  <InputSelect
+                    variant="secondary"
+                    size={size}
+                    value={simpleValue}
+                    onChange={setSimpleValue}
+                    options={SIMPLE_OPTIONS}
+                    placeholder="Secondary"
+                  />
+                  <InputSelect
+                    variant="danger"
+                    size={size}
+                    value={simpleValue}
+                    onChange={setSimpleValue}
+                    options={SIMPLE_OPTIONS}
+                    placeholder="Danger"
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* States */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">States</h2>
+          <div className="space-y-4 max-w-md">
+            <InputSelect
+              label="With Error"
+              error="Please select a valid option"
+              value={errorValue}
+              onChange={setErrorValue}
+              options={SIMPLE_OPTIONS}
+            />
+            <InputSelect
+              label="Disabled"
+              value={disabledValue}
+              onChange={setDisabledValue}
+              options={SIMPLE_OPTIONS}
+              disabled
+            />
+            <InputSelect
+              label="Required Field"
+              required
+              value={requiredValue}
+              onChange={setRequiredValue}
+              options={SIMPLE_OPTIONS}
+            />
+          </div>
+        </section>
+
+        {/* Use Cases */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">Use Cases</h2>
+          <div className="space-y-6">
+            {/* Category Selection */}
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-zinc-400 uppercase tracking-wide">
+                Category Selection
+              </h3>
+              <InputSelect
+                label="Task Category"
+                value={categoryValue}
+                onChange={setCategoryValue}
+                options={CATEGORY_OPTIONS}
+                placeholder="Choose a category"
+                description="Select the category this task belongs to"
+              />
+            </div>
+
+            {/* Options with Descriptions */}
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-zinc-400 uppercase tracking-wide">
+                Options with Descriptions
+              </h3>
+              <InputSelect
+                label="Recurrence"
+                value={recurrenceValue}
+                onChange={setRecurrenceValue}
+                options={OPTIONS_WITH_DESCRIPTIONS}
+                placeholder="Select recurrence pattern"
+              />
+            </div>
+
+            {/* Priority Selection */}
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-zinc-400 uppercase tracking-wide">
+                Priority Selection
+              </h3>
+              <InputSelect
+                label="Priority"
+                value={priorityValue}
+                onChange={setPriorityValue}
+                options={PRIORITY_OPTIONS}
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* Full Width */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">Full Width</h2>
+          <InputSelect
+            label="Full Width Select"
+            fullWidth
+            value={simpleValue}
+            onChange={setSimpleValue}
+            options={SIMPLE_OPTIONS}
+            placeholder="This select takes full width"
+          />
+        </section>
+
+        {/* Comparison with FormSelect */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">
+            Comparison with FormSelect
+          </h2>
+          <div className="space-y-4">
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 space-y-4">
+              <h3 className="text-sm font-semibold text-zinc-300">
+                InputSelect (New)
+              </h3>
+              <InputSelect
+                label="Category"
+                value={categoryValue}
+                onChange={setCategoryValue}
+                options={CATEGORY_OPTIONS}
+                description="Uses InputHeader, consistent with Input/InputArea"
+              />
+              <p className="text-xs text-zinc-500">
+                ✅ Integrated label/error/description handling
+                <br />
+                ✅ Consistent variant/size system
+                <br />✅ No FormField wrapper needed
+              </p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Added an InputSelect component to be reused across the app.
Will be useful for complex forms that have multi-option fields like the category field in the create task modal

Also added a InputSelect showcase */showcase/inputselect

Examples:
<img width="496" height="878" alt="inputSelectShowcase1" src="https://github.com/user-attachments/assets/24386f55-95a0-4ca7-9905-2f7f94c2d4b1" />
<img width="490" height="904" alt="inputSelectShowcase2" src="https://github.com/user-attachments/assets/aeeb46bd-3d24-4d4a-9d8f-236e05ae427d" />
<img width="904" height="922" alt="inputSelectShowcase3" src="https://github.com/user-attachments/assets/ebd0c672-4c15-45ac-9fe5-0aababe554e1" />
<img width="200" height="226" alt="inputSelectShowcase4" src="https://github.com/user-attachments/assets/aa989bf8-f77c-49cb-bc9e-4106b4389399" />
