### PR TITLE
Feature: Added Divider

### DIFF
--- a/src/app/components/ui/Divider.tsx
+++ b/src/app/components/ui/Divider.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import clsx from 'clsx';
+import React from 'react';
+
+export type DividerOrientation = 'horizontal' | 'vertical';
+export type DividerVariant = 'subtle' | 'prominent';
+
+export interface DividerProps extends React.HTMLAttributes<HTMLDivElement> {
+  orientation?: DividerOrientation;
+  variant?: DividerVariant;
+  label?: React.ReactNode;
+  spacing?: 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  fullWidth?: boolean;
+}
+
+const orientationStyles: Record<DividerOrientation, string> = {
+  horizontal: 'w-full',
+  vertical: 'h-full w-px flex-shrink-0',
+};
+
+const variantBorderStyles: Record<DividerVariant, string> = {
+  subtle: 'border-white/10',
+  prominent: 'border-white/20',
+};
+
+const variantLabelStyles: Record<DividerVariant, string> = {
+  subtle: 'bg-zinc-900/60 text-zinc-400',
+  prominent: 'bg-zinc-900/80 text-zinc-300',
+};
+
+const spacingStyles: Record<
+  NonNullable<DividerProps['spacing']>,
+  Record<DividerOrientation, string>
+> = {
+  none: {
+    horizontal: 'my-0',
+    vertical: 'mx-0',
+  },
+  xs: {
+    horizontal: 'my-1',
+    vertical: 'mx-1',
+  },
+  sm: {
+    horizontal: 'my-2',
+    vertical: 'mx-2',
+  },
+  md: {
+    horizontal: 'my-4',
+    vertical: 'mx-4',
+  },
+  lg: {
+    horizontal: 'my-6',
+    vertical: 'mx-6',
+  },
+  xl: {
+    horizontal: 'my-8',
+    vertical: 'mx-8',
+  },
+};
+
+export function Divider({
+  orientation = 'horizontal',
+  variant = 'subtle',
+  label,
+  spacing = 'md',
+  fullWidth = true,
+  className,
+  ...props
+}: DividerProps) {
+  const isHorizontal = orientation === 'horizontal';
+  const hasLabel = !!label;
+
+  if (isHorizontal) {
+    return (
+      <div
+        className={clsx(
+          'relative',
+          spacingStyles[spacing].horizontal,
+          fullWidth ? 'w-full' : 'inline-block',
+          className,
+        )}
+        {...props}
+      >
+        {hasLabel ? (
+          <>
+            <div className="absolute inset-0 flex items-center">
+              <span
+                className={clsx(
+                  'w-full border-t',
+                  variantBorderStyles[variant],
+                )}
+              />
+            </div>
+            <div className="relative flex justify-center">
+              <span
+                className={clsx(
+                  'px-2 text-xs font-medium',
+                  variantLabelStyles[variant],
+                )}
+              >
+                {label}
+              </span>
+            </div>
+          </>
+        ) : (
+          <span
+            className={clsx(
+              'block w-full border-t',
+              variantBorderStyles[variant],
+            )}
+          />
+        )}
+      </div>
+    );
+  }
+
+  // Vertical divider
+  return (
+    <div
+      className={clsx(
+        'relative flex items-center',
+        spacingStyles[spacing].vertical,
+        className,
+      )}
+      role="separator"
+      aria-orientation="vertical"
+      {...props}
+    >
+      {hasLabel ? (
+        <div className="flex flex-col items-center h-full">
+          <span
+            className={clsx('flex-1 border-l', variantBorderStyles[variant])}
+          />
+          <span
+            className={clsx(
+              'px-1 py-2 text-xs font-medium whitespace-nowrap',
+              variantLabelStyles[variant],
+            )}
+          >
+            {label}
+          </span>
+          <span
+            className={clsx('flex-1 border-l', variantBorderStyles[variant])}
+          />
+        </div>
+      ) : (
+        <span
+          className={clsx('h-full border-l', variantBorderStyles[variant])}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/showcase/divider/page.tsx
+++ b/src/app/showcase/divider/page.tsx
@@ -1,0 +1,385 @@
+'use client';
+
+import { Divider } from '@pointwise/app/components/ui/Divider';
+import BackgroundGlow from '@pointwise/app/components/general/BackgroundGlow';
+
+export default function DividerShowcasePage() {
+  return (
+    <div className="relative min-h-screen bg-zinc-950 text-zinc-100 overflow-hidden">
+      <BackgroundGlow />
+      <div className="relative z-10 max-w-4xl mx-auto px-6 py-12 space-y-12">
+        <div>
+          <h1 className="text-3xl font-bold mb-2">Divider Showcase</h1>
+          <p className="text-sm text-zinc-400">
+            Comprehensive display of all divider variants, orientations, and use
+            cases
+          </p>
+        </div>
+
+        {/* Basic Horizontal Dividers */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">
+            Basic Horizontal Dividers
+          </h2>
+          <div className="space-y-6">
+            <div>
+              <p className="text-sm text-zinc-400 mb-2">Subtle variant</p>
+              <div className="bg-zinc-900/40 p-4 rounded-lg">
+                <p className="text-sm text-zinc-300 mb-4">
+                  Content above the divider
+                </p>
+                <Divider variant="subtle" />
+                <p className="text-sm text-zinc-300 mt-4">
+                  Content below the divider
+                </p>
+              </div>
+            </div>
+            <div>
+              <p className="text-sm text-zinc-400 mb-2">Prominent variant</p>
+              <div className="bg-zinc-900/40 p-4 rounded-lg">
+                <p className="text-sm text-zinc-300 mb-4">
+                  Content above the divider
+                </p>
+                <Divider variant="prominent" />
+                <p className="text-sm text-zinc-300 mt-4">
+                  Content below the divider
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Horizontal Dividers with Labels */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">
+            Horizontal Dividers with Labels
+          </h2>
+          <div className="space-y-6">
+            <div>
+              <p className="text-sm text-zinc-400 mb-2">
+                Subtle with "or" label
+              </p>
+              <div className="bg-zinc-900/40 p-4 rounded-lg">
+                <p className="text-sm text-zinc-300 mb-4">Sign in with email</p>
+                <Divider variant="subtle" label="or" />
+                <p className="text-sm text-zinc-300 mt-4">
+                  Sign in with social
+                </p>
+              </div>
+            </div>
+            <div>
+              <p className="text-sm text-zinc-400 mb-2">
+                Prominent with custom label
+              </p>
+              <div className="bg-zinc-900/40 p-4 rounded-lg">
+                <p className="text-sm text-zinc-300 mb-4">Section A</p>
+                <Divider variant="prominent" label="Section Break" />
+                <p className="text-sm text-zinc-300 mt-4">Section B</p>
+              </div>
+            </div>
+            <div>
+              <p className="text-sm text-zinc-400 mb-2">
+                With custom label content
+              </p>
+              <div className="bg-zinc-900/40 p-4 rounded-lg">
+                <p className="text-sm text-zinc-300 mb-4">Before</p>
+                <Divider
+                  variant="subtle"
+                  label={
+                    <span className="flex items-center gap-2">
+                      <span>•</span>
+                      <span>Continue</span>
+                      <span>•</span>
+                    </span>
+                  }
+                />
+                <p className="text-sm text-zinc-300 mt-4">After</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Spacing Variants */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">
+            Spacing Variants
+          </h2>
+          <div className="space-y-6">
+            {(['none', 'xs', 'sm', 'md', 'lg', 'xl'] as const).map(
+              (spacing) => (
+                <div key={spacing}>
+                  <p className="text-sm text-zinc-400 mb-2">
+                    Spacing: {spacing}
+                  </p>
+                  <div className="bg-zinc-900/40 p-4 rounded-lg">
+                    <p className="text-sm text-zinc-300">Content above</p>
+                    <Divider variant="subtle" spacing={spacing} />
+                    <p className="text-sm text-zinc-300">Content below</p>
+                  </div>
+                </div>
+              ),
+            )}
+          </div>
+        </section>
+
+        {/* Vertical Dividers */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">
+            Vertical Dividers
+          </h2>
+          <div className="space-y-6">
+            <div>
+              <p className="text-sm text-zinc-400 mb-2">
+                Basic vertical divider
+              </p>
+              <div className="bg-zinc-900/40 p-4 rounded-lg">
+                <div className="flex items-center h-20">
+                  <div className="flex-1 text-sm text-zinc-300">
+                    Left content
+                  </div>
+                  <Divider orientation="vertical" variant="subtle" />
+                  <div className="flex-1 text-sm text-zinc-300">
+                    Right content
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div>
+              <p className="text-sm text-zinc-400 mb-2">
+                Prominent vertical divider
+              </p>
+              <div className="bg-zinc-900/40 p-4 rounded-lg">
+                <div className="flex items-center h-20">
+                  <div className="flex-1 text-sm text-zinc-300">
+                    Left content
+                  </div>
+                  <Divider orientation="vertical" variant="prominent" />
+                  <div className="flex-1 text-sm text-zinc-300">
+                    Right content
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div>
+              <p className="text-sm text-zinc-400 mb-2">
+                Vertical divider with label
+              </p>
+              <div className="bg-zinc-900/40 p-4 rounded-lg">
+                <div className="flex items-center h-32">
+                  <div className="flex-1 text-sm text-zinc-300">
+                    Left section
+                  </div>
+                  <Divider
+                    orientation="vertical"
+                    variant="subtle"
+                    label="VS"
+                    spacing="sm"
+                  />
+                  <div className="flex-1 text-sm text-zinc-300">
+                    Right section
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Use Cases */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">Use Cases</h2>
+          <div className="space-y-6">
+            {/* Auth Form Divider */}
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-zinc-400 uppercase tracking-wide">
+                Auth Form (Current Pattern)
+              </h3>
+              <div className="bg-zinc-900/40 p-6 rounded-lg">
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-xs text-zinc-400 mb-1">
+                      Email
+                    </label>
+                    <input
+                      type="email"
+                      className="w-full rounded-lg bg-zinc-800 border border-white/10 px-3 py-2 text-sm outline-none"
+                      placeholder="Enter your email"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs text-zinc-400 mb-1">
+                      Password
+                    </label>
+                    <input
+                      type="password"
+                      className="w-full rounded-lg bg-zinc-800 border border-white/10 px-3 py-2 text-sm outline-none"
+                      placeholder="Enter your password"
+                    />
+                  </div>
+                  <button className="w-full rounded-lg bg-indigo-500 px-4 py-2 text-sm font-medium">
+                    Sign In
+                  </button>
+                  <Divider variant="subtle" label="or" spacing="md" />
+                  <div className="flex gap-2">
+                    <button className="flex-1 rounded-lg border border-white/10 bg-zinc-800 px-4 py-2 text-sm">
+                      Google
+                    </button>
+                    <button className="flex-1 rounded-lg border border-white/10 bg-zinc-800 px-4 py-2 text-sm">
+                      GitHub
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Section Separator */}
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-zinc-400 uppercase tracking-wide">
+                Section Separator
+              </h3>
+              <div className="bg-zinc-900/40 p-6 rounded-lg space-y-4">
+                <div>
+                  <h4 className="text-base font-semibold mb-2">
+                    Profile Settings
+                  </h4>
+                  <p className="text-sm text-zinc-400">
+                    Manage your personal information and preferences
+                  </p>
+                </div>
+                <Divider variant="subtle" spacing="lg" />
+                <div>
+                  <h4 className="text-base font-semibold mb-2">Security</h4>
+                  <p className="text-sm text-zinc-400">
+                    Update your password and security settings
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* List Item Separator */}
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-zinc-400 uppercase tracking-wide">
+                List Item Separator
+              </h3>
+              <div className="bg-zinc-900/40 p-4 rounded-lg">
+                <div className="space-y-0">
+                  <div className="py-3">
+                    <p className="text-sm font-medium">Task 1</p>
+                    <p className="text-xs text-zinc-400">Description</p>
+                  </div>
+                  <Divider variant="subtle" spacing="none" />
+                  <div className="py-3">
+                    <p className="text-sm font-medium">Task 2</p>
+                    <p className="text-xs text-zinc-400">Description</p>
+                  </div>
+                  <Divider variant="subtle" spacing="none" />
+                  <div className="py-3">
+                    <p className="text-sm font-medium">Task 3</p>
+                    <p className="text-xs text-zinc-400">Description</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Sidebar Layout */}
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-zinc-400 uppercase tracking-wide">
+                Sidebar Layout (Vertical)
+              </h3>
+              <div className="bg-zinc-900/40 p-4 rounded-lg">
+                <div className="flex h-40">
+                  <div className="flex-1 space-y-2">
+                    <p className="text-sm font-medium">Navigation</p>
+                    <ul className="text-xs text-zinc-400 space-y-1">
+                      <li>Home</li>
+                      <li>Dashboard</li>
+                      <li>Settings</li>
+                    </ul>
+                  </div>
+                  <Divider
+                    orientation="vertical"
+                    variant="subtle"
+                    spacing="md"
+                  />
+                  <div className="flex-1">
+                    <p className="text-sm font-medium mb-2">Main Content</p>
+                    <p className="text-xs text-zinc-400">
+                      This is the main content area separated by a vertical
+                      divider.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Comparison View */}
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-zinc-400 uppercase tracking-wide">
+                Comparison View
+              </h3>
+              <div className="bg-zinc-900/40 p-4 rounded-lg">
+                <div className="flex h-48">
+                  <div className="flex-1">
+                    <p className="text-sm font-semibold mb-2">Plan A</p>
+                    <ul className="text-xs text-zinc-400 space-y-1">
+                      <li>Feature 1</li>
+                      <li>Feature 2</li>
+                      <li>Feature 3</li>
+                    </ul>
+                  </div>
+                  <Divider
+                    orientation="vertical"
+                    variant="prominent"
+                    label="VS"
+                    spacing="lg"
+                  />
+                  <div className="flex-1">
+                    <p className="text-sm font-semibold mb-2">Plan B</p>
+                    <ul className="text-xs text-zinc-400 space-y-1">
+                      <li>Feature 1</li>
+                      <li>Feature 2</li>
+                      <li>Feature 3</li>
+                      <li>Feature 4</li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Full Width vs Inline */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">
+            Full Width vs Inline
+          </h2>
+          <div className="space-y-6">
+            <div>
+              <p className="text-sm text-zinc-400 mb-2">Full width (default)</p>
+              <div className="bg-zinc-900/40 p-4 rounded-lg">
+                <p className="text-sm text-zinc-300 mb-4">Content</p>
+                <Divider variant="subtle" />
+                <p className="text-sm text-zinc-300 mt-4">Content</p>
+              </div>
+            </div>
+            <div>
+              <p className="text-sm text-zinc-400 mb-2">
+                Inline (not full width)
+              </p>
+              <div className="bg-zinc-900/40 p-4 rounded-lg">
+                <p className="text-sm text-zinc-300 mb-4">Content</p>
+                <div className="flex justify-center">
+                  <Divider
+                    variant="subtle"
+                    fullWidth={false}
+                    className="w-32"
+                  />
+                </div>
+                <p className="text-sm text-zinc-300 mt-4">Content</p>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Added reusable divider component, useful for dividing sections examples:
- Login form or OAuth (Google/Github)
- Side Menu divider page content

Also added a showcase page:
*/showcase/divider

Examples:
<img width="1424" height="1704" alt="dividerShowcase1" src="https://github.com/user-attachments/assets/4473556b-a213-4fc7-9577-bbf42d86c70b" />
<img width="1424" height="1550" alt="dividerShowcase2" src="https://github.com/user-attachments/assets/be4b2b68-4bbd-4a38-ba75-30327529cf2d" />
<img width="1428" height="1672" alt="dividerShowcase3" src="https://github.com/user-attachments/assets/9c026fca-dfc5-46f5-8f1b-7ad6db943080" />
<img width="1406" height="1668" alt="dividerShowcase4" src="https://github.com/user-attachments/assets/3578f095-8059-41fb-9ccc-aeb82d13d994" />
