### PR TITLE
Feature: Added Tabs

### DIFF
--- a/src/app/components/ui/Tabs.tsx
+++ b/src/app/components/ui/Tabs.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import clsx from 'clsx';
+import React from 'react';
+
+export type TabsVariant = 'primary' | 'secondary';
+export type TabsSize = 'sm' | 'md' | 'lg';
+
+export interface TabItem {
+  /**
+   * Unique identifier for the tab
+   */
+  id: string;
+  /**
+   * Label to display on the tab
+   */
+  label: React.ReactNode;
+  /**
+   * Optional icon to display with the label
+   */
+  icon?: React.ReactNode;
+  /**
+   * Whether the tab is disabled
+   */
+  disabled?: boolean;
+}
+
+export interface TabsProps {
+  /**
+   * Array of tab items to display
+   */
+  items: TabItem[];
+  /**
+   * Currently active tab ID
+   */
+  value: string;
+  /**
+   * Callback when a tab is selected
+   */
+  onChange: (value: string) => void;
+  /**
+   * Visual variant of the tabs
+   * @default 'primary'
+   */
+  variant?: TabsVariant;
+  /**
+   * Size of the tabs
+   * @default 'md'
+   */
+  size?: TabsSize;
+  /**
+   * Whether tabs should take full width
+   * @default true
+   */
+  fullWidth?: boolean;
+  /**
+   * Custom className for the container
+   */
+  className?: string;
+}
+
+const variantStyles: Record<TabsVariant, string> = {
+  primary: 'bg-zinc-800/60',
+  secondary: 'bg-zinc-900/40',
+};
+
+const sizeStyles: Record<TabsSize, string> = {
+  sm: 'p-0.5',
+  md: 'p-1',
+  lg: 'p-1.5',
+};
+
+const tabSizeStyles: Record<TabsSize, string> = {
+  sm: 'py-1 text-xs',
+  md: 'py-2 text-sm',
+  lg: 'py-2.5 text-base',
+};
+
+const activeTabStyles: Record<TabsVariant, string> = {
+  primary: 'bg-zinc-950 text-white',
+  secondary: 'bg-zinc-800 text-white',
+};
+
+const inactiveTabStyles: Record<TabsVariant, string> = {
+  primary: 'text-zinc-400 hover:text-zinc-200',
+  secondary: 'text-zinc-500 hover:text-zinc-300',
+};
+
+export function Tabs({
+  items,
+  value,
+  onChange,
+  variant = 'primary',
+  size = 'md',
+  fullWidth = true,
+  className,
+}: TabsProps) {
+  return (
+    <div
+      className={clsx(
+        'flex rounded-xl',
+        variantStyles[variant],
+        sizeStyles[size],
+        fullWidth ? 'w-full' : 'inline-flex',
+        className,
+      )}
+      role="tablist"
+      aria-label="Tabs"
+    >
+      {items.map((item) => {
+        const isActive = value === item.id;
+        const isDisabled = item.disabled;
+
+        return (
+          <button
+            key={item.id}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            aria-controls={`tabpanel-${item.id}`}
+            id={`tab-${item.id}`}
+            disabled={isDisabled}
+            onClick={() => !isDisabled && onChange(item.id)}
+            className={clsx(
+              'flex-1 flex items-center justify-center gap-2 rounded-lg transition focus:outline-none focus:ring-2 focus:ring-fuchsia-500/40',
+              tabSizeStyles[size],
+              isDisabled && 'opacity-50 cursor-not-allowed',
+              !isDisabled &&
+                (isActive
+                  ? activeTabStyles[variant]
+                  : inactiveTabStyles[variant]),
+            )}
+          >
+            {item.icon && <span className="shrink-0">{item.icon}</span>}
+            <span>{item.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/showcase/tabs/page.tsx
+++ b/src/app/showcase/tabs/page.tsx
@@ -1,0 +1,321 @@
+'use client';
+
+import { useState } from 'react';
+import { Tabs } from '@pointwise/app/components/ui/Tabs';
+import { Card } from '@pointwise/app/components/ui/Card';
+import BackgroundGlow from '@pointwise/app/components/general/BackgroundGlow';
+import { FiHome, FiSettings, FiUser, FiMail, FiStar } from 'react-icons/fi';
+
+export default function TabsShowcasePage() {
+  const [basicTab, setBasicTab] = useState('tab1');
+  const [variantTab, setVariantTab] = useState('tab1');
+  const [sizeTab, setSizeTab] = useState('tab1');
+  const [iconTab, setIconTab] = useState('home');
+  const [disabledTab, setDisabledTab] = useState('tab1');
+  const [multiTab, setMultiTab] = useState('tab1');
+
+  return (
+    <div className="relative min-h-screen bg-zinc-950 text-zinc-100 overflow-hidden">
+      <BackgroundGlow />
+      <div className="relative z-10 max-w-4xl mx-auto px-6 py-12 space-y-12">
+        <div>
+          <h1 className="text-3xl font-bold mb-2">Tabs Component Showcase</h1>
+          <p className="text-sm text-zinc-400">
+            Display of Tabs component variants, sizes, and use cases
+          </p>
+        </div>
+
+        {/* Basic Usage */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">Basic Usage</h2>
+          <p className="text-xs text-zinc-500">
+            Simple two-tab example (like authentication page)
+          </p>
+          <Card variant="primary" responsivePadding>
+            <Tabs
+              items={[
+                { id: 'tab1', label: 'Sign In' },
+                { id: 'tab2', label: 'Sign Up' },
+              ]}
+              value={basicTab}
+              onChange={setBasicTab}
+            />
+            <div className="mt-4">
+              <p className="text-sm text-zinc-300">
+                Active tab: <span className="font-semibold">{basicTab}</span>
+              </p>
+            </div>
+          </Card>
+        </section>
+
+        {/* Variants */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">Variants</h2>
+          <p className="text-xs text-zinc-500">
+            Different visual styles for tabs
+          </p>
+          <div className="space-y-6">
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-zinc-400">
+                Primary Variant (Default)
+              </h3>
+              <Tabs
+                items={[
+                  { id: 'tab1', label: 'Tab 1' },
+                  { id: 'tab2', label: 'Tab 2' },
+                  { id: 'tab3', label: 'Tab 3' },
+                ]}
+                value={variantTab}
+                onChange={setVariantTab}
+                variant="primary"
+              />
+            </div>
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-zinc-400">
+                Secondary Variant
+              </h3>
+              <Tabs
+                items={[
+                  { id: 'tab1', label: 'Tab 1' },
+                  { id: 'tab2', label: 'Tab 2' },
+                  { id: 'tab3', label: 'Tab 3' },
+                ]}
+                value={variantTab}
+                onChange={setVariantTab}
+                variant="secondary"
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* Sizes */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">Sizes</h2>
+          <p className="text-xs text-zinc-500">
+            Different size options for tabs
+          </p>
+          <div className="space-y-6">
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-zinc-400">Small</h3>
+              <Tabs
+                items={[
+                  { id: 'tab1', label: 'Small Tab 1' },
+                  { id: 'tab2', label: 'Small Tab 2' },
+                ]}
+                value={sizeTab}
+                onChange={setSizeTab}
+                size="sm"
+              />
+            </div>
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-zinc-400">
+                Medium (Default)
+              </h3>
+              <Tabs
+                items={[
+                  { id: 'tab1', label: 'Medium Tab 1' },
+                  { id: 'tab2', label: 'Medium Tab 2' },
+                ]}
+                value={sizeTab}
+                onChange={setSizeTab}
+                size="md"
+              />
+            </div>
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-zinc-400">Large</h3>
+              <Tabs
+                items={[
+                  { id: 'tab1', label: 'Large Tab 1' },
+                  { id: 'tab2', label: 'Large Tab 2' },
+                ]}
+                value={sizeTab}
+                onChange={setSizeTab}
+                size="lg"
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* With Icons */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">With Icons</h2>
+          <p className="text-xs text-zinc-500">
+            Tabs can include icons alongside labels
+          </p>
+          <Tabs
+            items={[
+              { id: 'home', label: 'Home', icon: <FiHome /> },
+              { id: 'settings', label: 'Settings', icon: <FiSettings /> },
+              { id: 'profile', label: 'Profile', icon: <FiUser /> },
+            ]}
+            value={iconTab}
+            onChange={setIconTab}
+          />
+          <div className="mt-4">
+            <p className="text-sm text-zinc-300">
+              Active tab: <span className="font-semibold">{iconTab}</span>
+            </p>
+          </div>
+        </section>
+
+        {/* Disabled State */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">
+            Disabled State
+          </h2>
+          <p className="text-xs text-zinc-500">
+            Tabs can be disabled individually
+          </p>
+          <Tabs
+            items={[
+              { id: 'tab1', label: 'Active Tab' },
+              { id: 'tab2', label: 'Disabled Tab', disabled: true },
+              { id: 'tab3', label: 'Another Active Tab' },
+            ]}
+            value={disabledTab}
+            onChange={setDisabledTab}
+          />
+        </section>
+
+        {/* Multiple Tabs */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">Multiple Tabs</h2>
+          <p className="text-xs text-zinc-500">
+            Tabs component supports any number of tabs
+          </p>
+          <Tabs
+            items={[
+              { id: 'tab1', label: 'First' },
+              { id: 'tab2', label: 'Second' },
+              { id: 'tab3', label: 'Third' },
+              { id: 'tab4', label: 'Fourth' },
+              { id: 'tab5', label: 'Fifth' },
+            ]}
+            value={multiTab}
+            onChange={setMultiTab}
+          />
+          <div className="mt-4">
+            <p className="text-sm text-zinc-300">
+              Active tab: <span className="font-semibold">{multiTab}</span>
+            </p>
+          </div>
+        </section>
+
+        {/* Full Width vs Inline */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">
+            Full Width vs Inline
+          </h2>
+          <p className="text-xs text-zinc-500">
+            Tabs can take full width or be inline
+          </p>
+          <div className="space-y-6">
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-zinc-400">
+                Full Width (Default)
+              </h3>
+              <Tabs
+                items={[
+                  { id: 'tab1', label: 'Tab 1' },
+                  { id: 'tab2', label: 'Tab 2' },
+                ]}
+                value={basicTab}
+                onChange={setBasicTab}
+                fullWidth
+              />
+            </div>
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-zinc-400">Inline</h3>
+              <Tabs
+                items={[
+                  { id: 'tab1', label: 'Tab 1' },
+                  { id: 'tab2', label: 'Tab 2' },
+                ]}
+                value={basicTab}
+                onChange={setBasicTab}
+                fullWidth={false}
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* Real-world Example */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">
+            Real-world Example
+          </h2>
+          <p className="text-xs text-zinc-500">
+            Example usage in a card with content switching
+          </p>
+          <Card variant="primary" responsivePadding>
+            <Tabs
+              items={[
+                { id: 'inbox', label: 'Inbox', icon: <FiMail /> },
+                { id: 'starred', label: 'Starred', icon: <FiStar /> },
+                { id: 'settings', label: 'Settings', icon: <FiSettings /> },
+              ]}
+              value={iconTab}
+              onChange={setIconTab}
+            />
+            <div className="mt-6">
+              {iconTab === 'inbox' && (
+                <div className="space-y-2">
+                  <h3 className="text-lg font-semibold">Inbox</h3>
+                  <p className="text-sm text-zinc-400">
+                    Your inbox messages will appear here.
+                  </p>
+                </div>
+              )}
+              {iconTab === 'starred' && (
+                <div className="space-y-2">
+                  <h3 className="text-lg font-semibold">Starred</h3>
+                  <p className="text-sm text-zinc-400">
+                    Your starred items will appear here.
+                  </p>
+                </div>
+              )}
+              {iconTab === 'settings' && (
+                <div className="space-y-2">
+                  <h3 className="text-lg font-semibold">Settings</h3>
+                  <p className="text-sm text-zinc-400">
+                    Your settings will appear here.
+                  </p>
+                </div>
+              )}
+            </div>
+          </Card>
+        </section>
+
+        {/* Code Example */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-zinc-200">Usage Example</h2>
+          <Card variant="secondary">
+            <pre className="text-xs text-zinc-400 overflow-x-auto">
+              <code>{`import { Tabs } from '@pointwise/app/components/ui/Tabs';
+import { useState } from 'react';
+
+function MyComponent() {
+  const [activeTab, setActiveTab] = useState('tab1');
+
+  return (
+    <Tabs
+      items={[
+        { id: 'tab1', label: 'Tab 1' },
+        { id: 'tab2', label: 'Tab 2', icon: <Icon /> },
+        { id: 'tab3', label: 'Tab 3', disabled: true },
+      ]}
+      value={activeTab}
+      onChange={setActiveTab}
+      variant="primary"
+      size="md"
+      fullWidth
+    />
+  );
+}`}</code>
+            </pre>
+          </Card>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Added a reusable tabs component, mainly to be used on the Auth page.

Also added a showcase:
*/showcase/tabs

Examples:
<img width="708" height="828" alt="tabsShowcase1" src="https://github.com/user-attachments/assets/23cc8589-5aec-417c-a915-f464d5a58625" />
<img width="710" height="680" alt="tabsShowcase2" src="https://github.com/user-attachments/assets/4488c07b-1680-46d5-9b26-b5ba90d8351b" />
<img width="716" height="618" alt="tabsShowcase3" src="https://github.com/user-attachments/assets/a585fff9-6585-470a-9e2c-8e47bc761608" />