### PR TITLE
Not Found page & Auto Redirect

### DIFF
--- a/src/app/components/general/AutoRedirectNotice.tsx
+++ b/src/app/components/general/AutoRedirectNotice.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import { Button } from '../ui/Button';
+import { Spinner } from '../ui/Spinner';
+
+type AutoRedirectNoticeProps = {
+  target: string;
+  label: string;
+  description: string;
+  delayMs?: number;
+};
+
+export function AutoRedirectNotice({
+  target,
+  label,
+  description,
+  delayMs = 5000,
+}: AutoRedirectNoticeProps) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      router.push(target);
+    }, delayMs);
+
+    return () => clearTimeout(timeoutId);
+  }, [router, target, delayMs]);
+
+  return (
+    <div className="mt-2 flex flex-col items-center gap-4">
+      <div className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-zinc-900/80 px-4 py-2 text-xs text-zinc-300">
+        <Spinner
+          size="sm"
+          variant="primary"
+          type="dots"
+          aria-label="Redirecting"
+        />
+        <span>{description}</span>
+      </div>
+
+      <div className="text-[11px] text-zinc-500">
+        Not redirected? Use the button below.
+      </div>
+
+      <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+        <Link href={target} className="w-full sm:w-48">
+          <Button variant="primary" fullWidth>
+            {label}
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,56 @@
+import { getServerSession } from 'next-auth';
+
+import { authOptions } from '@pointwise/lib/auth';
+import BackgroundGlow from './components/general/BackgroundGlow';
+import BrandHeader from './components/general/BrandHeader';
+import { AutoRedirectNotice } from './components/general/AutoRedirectNotice';
+import { Card } from './components/ui/Card';
+
+export default async function NotFound() {
+  const session = await getServerSession(authOptions);
+  const isSignedIn = Boolean(session);
+
+  const title = isSignedIn
+    ? "We couldn't find that page"
+    : "This route doesn't exist (yet)";
+
+  const description = isSignedIn
+    ? "This page isn't available right now. It may have moved, or you might not have access to it."
+    : "You've reached a page we haven't built or that no longer exists.";
+
+  const redirectTarget = isSignedIn ? '/dashboard' : '/';
+  const redirectLabel = isSignedIn ? 'Go to dashboard' : 'Go to home';
+  const redirectDescription = isSignedIn
+    ? 'Redirecting you to your dashboard in a few seconds…'
+    : 'Redirecting you to the home page in a few seconds…';
+
+  return (
+    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-zinc-950 px-4 py-20 text-zinc-100">
+      <BackgroundGlow />
+
+      <div className="relative z-10 w-full max-w-2xl space-y-10">
+        <BrandHeader />
+
+        <Card className="space-y-9 border-white/10 bg-zinc-950/80 p-8 text-center shadow-xl shadow-black/40 sm:p-12">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-zinc-500">
+            404 • Page not found
+          </p>
+
+          <h1 className="text-2xl font-semibold tracking-tight p-2 sm:text-3xl">
+            {title}
+          </h1>
+
+          <p className="mx-auto max-w-lg text-sm leading-relaxed text-zinc-400 sm:text-[0.95rem] mt-2 sm:mt-3">
+            {description}
+          </p>
+
+          <AutoRedirectNotice
+            target={redirectTarget}
+            label={redirectLabel}
+            description={redirectDescription}
+          />
+        </Card>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Added a not found page for 404 that automatically redirects the user in 5 seconds or provides a button to click to manually redirect.

Automatically directs to dashboard if user has an active session otherwise the homepage / authentication page

Example:
https://github.com/user-attachments/assets/e926dcd6-e41a-4a91-b959-09615c722730