### PR TITLE
Fix #41: Project description cannot be cleared when updating

### DIFF
--- a/src/app/components/dashboard/ProjectManagementModal.tsx
+++ b/src/app/components/dashboard/ProjectManagementModal.tsx
@@ -105,7 +105,7 @@ export function ProjectManagementModal({
 			if (mode === "create") {
 				const result = await createProject({
 					name: name.trim(),
-					description: description.trim() || undefined,
+					description: description.trim() || null,
 					visibility,
 				}).unwrap();
 
@@ -118,7 +118,7 @@ export function ProjectManagementModal({
 					projectId,
 					data: {
 						name: name.trim(),
-						description: description.trim() || undefined,
+						description: description.trim() || null,
 						visibility,
 					},
 				}).unwrap();

--- a/src/app/components/dashboard/ProjectSettingsModal.tsx
+++ b/src/app/components/dashboard/ProjectSettingsModal.tsx
@@ -103,7 +103,7 @@ export function ProjectSettingsModal({
 				projectId,
 				data: {
 					name: name.trim(),
-					description: description.trim() || undefined,
+					description: description.trim() || null,
 					visibility,
 				},
 			}).unwrap();

--- a/src/app/dashboardV2/modals/CreateProjectModal.tsx
+++ b/src/app/dashboardV2/modals/CreateProjectModal.tsx
@@ -2,18 +2,19 @@
 
 import { Button } from "@pointwise/app/components/ui/Button";
 import Container from "@pointwise/app/components/ui/Container";
-import InputAreaV2 from "@pointwise/app/components/ui/InputAreaV2";
-import InputV2 from "@pointwise/app/components/ui/InputV2";
 import ModalV2 from "@pointwise/app/components/ui/modalV2";
-import Selector from "@pointwise/app/components/ui/Selector";
 import { useCreateProjectMutation } from "@pointwise/lib/redux/services/projectsApi";
 import { useState } from "react";
-import { IoGlobe, IoLockClosed } from "react-icons/io5";
+import ProjectDescription from "./ProjectDescription";
+import ProjectName from "./ProjectName";
+import VisibilitySelector from "./VisibilitySelector";
 
 export default function CreateProjectModal() {
+	const defaultVisibility = "PRIVATE";
+
 	const [name, setName] = useState<string>("");
 	const [description, setDescription] = useState<string>("");
-	const [visibility, setVisibility] = useState<"PUBLIC" | "PRIVATE">("PRIVATE");
+	const [visibility, setVisibility] = useState<"PUBLIC" | "PRIVATE">(defaultVisibility);
 
 	const [createProject, { isLoading }] = useCreateProjectMutation();
 
@@ -21,7 +22,7 @@ export default function CreateProjectModal() {
 		try {
 			await createProject({
 				name: name.trim(),
-				description: description.trim() || undefined,
+				description: description?.trim() || null,
 				visibility,
 			}).unwrap();
 			ModalV2.Manager.close("create-project-modal");
@@ -30,45 +31,20 @@ export default function CreateProjectModal() {
 		}
 	};
 
+	const handleReset = () => {
+		setName("");
+		setDescription("");
+		setVisibility(defaultVisibility);
+	};
+
 	return (
-		<ModalV2 id="create-project-modal" size="lg">
+		<ModalV2 id="create-project-modal" size="lg" onAfterClose={handleReset}>
 			<ModalV2.Header title="Create Project" />
 			<ModalV2.Body>
 				<Container direction="vertical" gap="md" className="items-stretch">
-					<InputV2
-						label="Project Name"
-						placeholder="My Project"
-						required
-						flex="grow"
-						onChange={setName}
-					/>
-					<InputAreaV2
-						label="Description"
-						placeholder="What is this project about?"
-						rows={3}
-						flex="grow"
-						onChange={setDescription}
-					/>
-					<Selector
-						label="Visibility"
-						defaultValue="PRIVATE"
-						gap="md"
-						flex="grow"
-						onChange={(value) => setVisibility(value as "PUBLIC" | "PRIVATE")}
-					>
-						<Selector.Option
-							icon={IoLockClosed}
-							description="Only you can access"
-							value="PRIVATE"
-							label="Private"
-						/>
-						<Selector.Option
-							icon={IoGlobe}
-							description="Anyone can access"
-							value="PUBLIC"
-							label="Public"
-						/>
-					</Selector>
+					<ProjectName onChange={setName} />
+					<ProjectDescription onChange={setDescription} />
+					<VisibilitySelector defaultValue={defaultVisibility} onChange={setVisibility} />
 				</Container>
 			</ModalV2.Body>
 			<ModalV2.Footer align="end">

--- a/src/app/dashboardV2/modals/ProjectDescription.tsx
+++ b/src/app/dashboardV2/modals/ProjectDescription.tsx
@@ -1,0 +1,19 @@
+import InputAreaV2 from "@pointwise/app/components/ui/InputAreaV2";
+
+export interface ProjectDescriptionProps {
+	defaultValue?: string;
+	onChange?: (value: string) => void;
+}
+
+export default function ProjectDescription({ defaultValue, onChange }: ProjectDescriptionProps) {
+	return (
+		<InputAreaV2
+			label="Description"
+			placeholder="What is this project about?"
+			rows={3}
+			flex="grow"
+			defaultValue={defaultValue !== undefined ? defaultValue : ""}
+			onChange={onChange !== undefined ? (value) => onChange(value) : undefined}
+		/>
+	);
+}

--- a/src/app/dashboardV2/modals/ProjectName.tsx
+++ b/src/app/dashboardV2/modals/ProjectName.tsx
@@ -1,0 +1,19 @@
+import InputV2 from "@pointwise/app/components/ui/InputV2";
+
+export interface ProjectNameProps {
+	defaultValue?: string;
+	onChange?: (value: string) => void;
+}
+
+export default function ProjectName({ defaultValue, onChange }: ProjectNameProps) {
+	return (
+		<InputV2
+			label="Project Name"
+			placeholder="My Project"
+			required
+			flex="grow"
+			defaultValue={defaultValue !== undefined ? defaultValue : ""}
+			onChange={onChange !== undefined ? (value) => onChange(value) : undefined}
+		/>
+	);
+}

--- a/src/app/dashboardV2/modals/VisibilitySelector.tsx
+++ b/src/app/dashboardV2/modals/VisibilitySelector.tsx
@@ -1,0 +1,34 @@
+import Selector from "@pointwise/app/components/ui/Selector";
+import { IoGlobe, IoLockClosed } from "react-icons/io5";
+
+export interface VisibilitySelectorProps {
+	defaultValue?: "PUBLIC" | "PRIVATE";
+	onChange?: (value: "PUBLIC" | "PRIVATE") => void;
+}
+
+export default function VisibilitySelector({ defaultValue, onChange }: VisibilitySelectorProps) {
+	return (
+		<Selector
+			label="Visibility"
+			defaultValue={defaultValue !== undefined ? defaultValue : "PRIVATE"}
+			gap="md"
+			flex="grow"
+			onChange={(value) =>
+				onChange !== undefined ? onChange(value as "PUBLIC" | "PRIVATE") : undefined
+			}
+		>
+			<Selector.Option
+				icon={IoLockClosed}
+				description="Only you can access"
+				value="PRIVATE"
+				label="Private"
+			/>
+			<Selector.Option
+				icon={IoGlobe}
+				description="Anyone can access"
+				value="PUBLIC"
+				label="Public"
+			/>
+		</Selector>
+	);
+}

--- a/src/lib/api/projectsV2.ts
+++ b/src/lib/api/projectsV2.ts
@@ -177,7 +177,7 @@ export async function updateProject(
 		},
 		data: {
 			name: request.name,
-			description: request.description,
+			description: request.description ?? null,
 			visibility: request.visibility,
 		},
 		include: {


### PR DESCRIPTION
Fixes #41

## Summary
Fixes the bug where project descriptions could not be cleared when updating a project. Empty strings were being passed as `undefined`, which Prisma ignores in updates, preventing the description from being cleared.

## Changes
- **API Fix**: Updated `updateProject` to normalize `undefined` to `null` (matching `createProject` behavior)
- **Frontend Fix**: Changed all modals to convert empty description strings to `null` instead of `undefined`
- **Refactoring**: Extracted CreateProjectModal into reusable sub-components (ProjectName, ProjectDescription, VisibilitySelector)
- **UX Improvement**: Added form reset on modal close to prevent state persistence

## Testing
- ✅ Verified empty descriptions are properly cleared in database
- ✅ Tested creating projects with/without descriptions
- ✅ Tested updating projects to clear existing descriptions
- ✅ Verified form resets correctly when modal closes