### PR TITLE
Add DeleteProjectModal

### DIFF
--- a/src/app/dashboardV2/modals/DeleteProjectModal.tsx
+++ b/src/app/dashboardV2/modals/DeleteProjectModal.tsx
@@ -1,0 +1,67 @@
+import { Button } from "@pointwise/app/components/ui/Button";
+import Container from "@pointwise/app/components/ui/Container";
+import InputV2 from "@pointwise/app/components/ui/InputV2";
+import ModalV2 from "@pointwise/app/components/ui/modalV2";
+import { useDeleteProjectMutation } from "@pointwise/lib/redux/services/projectsApi";
+import type { Project } from "@pointwise/lib/validation/projects-schema";
+import { useState } from "react";
+
+export default function DeleteProjectModal({ project }: { project: Project }) {
+	const [deleteString, setDeleteString] = useState<string>("");
+
+	const [deleteProject, { isLoading: isDeleting }] = useDeleteProjectMutation();
+
+	const handleDeleteProject = async () => {
+		try {
+			await deleteProject(project.id).unwrap();
+			ModalV2.Manager.close(`delete-project-modal-${project.id}`);
+		} catch (error) {
+			console.error(error);
+		}
+	};
+
+	const handleReset = () => {
+		setDeleteString("");
+	};
+
+	return (
+		<ModalV2
+			id={`delete-project-modal-${project.id}`}
+			size="lg"
+			loading={isDeleting}
+			onAfterClose={handleReset}
+		>
+			<ModalV2.Header title="Delete Project" />
+			<ModalV2.Body>
+				<Container direction="vertical" gap="sm" className="items-stretch">
+					<div className="px-4 py-3 bg-rose-500/10 border border-rose-400/20 rounded-lg">
+						<p className="text-rose-400 text-sm font-medium mb-2">This action cannot be undone</p>
+						<p className="text-zinc-400 text-sm">
+							This will permanently delete the project and all associated tasks. All members will
+							lose access to this project.
+						</p>
+					</div>
+					<span className="text-sm font-medium text-zinc-300 pl-4 pt-2">
+						Enter the project name to delete: {project.name}
+					</span>
+					<InputV2
+						placeholder={project.name}
+						defaultValue={""}
+						onChange={setDeleteString}
+						flex="grow"
+					/>
+				</Container>
+			</ModalV2.Body>
+			<ModalV2.Footer>
+				<Button variant="secondary">Cancel</Button>
+				<Button
+					variant="danger"
+					disabled={deleteString !== project.name}
+					onClick={handleDeleteProject}
+				>
+					Delete
+				</Button>
+			</ModalV2.Footer>
+		</ModalV2>
+	);
+}

--- a/src/app/dashboardV2/modals/UpdateProjectModal.tsx
+++ b/src/app/dashboardV2/modals/UpdateProjectModal.tsx
@@ -3,12 +3,10 @@
 import { Button } from "@pointwise/app/components/ui/Button";
 import Container from "@pointwise/app/components/ui/Container";
 import ModalV2 from "@pointwise/app/components/ui/modalV2";
-import {
-	useDeleteProjectMutation,
-	useUpdateProjectMutation,
-} from "@pointwise/lib/redux/services/projectsApi";
+import { useUpdateProjectMutation } from "@pointwise/lib/redux/services/projectsApi";
 import type { Project } from "@pointwise/lib/validation/projects-schema";
 import { useEffect, useState } from "react";
+import DeleteProjectModal from "./DeleteProjectModal";
 import ProjectDescription from "./ProjectDescription";
 import ProjectName from "./ProjectName";
 import VisibilitySelector from "./VisibilitySelector";
@@ -23,40 +21,12 @@ export default function UpdateProjectModal({ project }: UpdateProjectModalProps)
 	const [visibility, setVisibility] = useState<"PUBLIC" | "PRIVATE">(project.visibility);
 
 	const [updateProject, { isLoading }] = useUpdateProjectMutation();
-	const [deleteProject, { isLoading: isDeleting }] = useDeleteProjectMutation();
 
 	useEffect(() => {
 		setName(project.name);
 		setDescription(project?.description ?? "");
 		setVisibility(project.visibility);
 	}, [project.name, project.description, project.visibility]);
-
-	const handleDeleteProject = async () => {
-		const confirmed = await ModalV2.Confirm({
-			title: "Delete Project",
-			message: `Are you sure you want to delete "${project.name}"? This action cannot be undone.`,
-			confirmText: "Delete",
-			cancelText: "Cancel",
-			confirmVariant: "danger",
-			cancelVariant: "secondary",
-		});
-
-		if (!confirmed) {
-			return;
-		}
-
-		try {
-			await deleteProject(project.id).unwrap();
-			ModalV2.Manager.close(`update-project-modal-${project.id}`);
-		} catch (error) {
-			console.error("Failed to delete project:", error);
-			await ModalV2.Alert({
-				title: "Error",
-				message: "Failed to delete project. Please try again.",
-				buttonVariant: "danger",
-			});
-		}
-	};
 
 	const handleUpdateProject = async () => {
 		try {
@@ -91,24 +61,33 @@ export default function UpdateProjectModal({ project }: UpdateProjectModalProps)
 	};
 
 	return (
-		<ModalV2 id={`update-project-modal-${project.id}`} size="lg" loading={isLoading || isDeleting}>
-			<ModalV2.Header title="Update Project" />
-			<ModalV2.Body>
-				<Container direction="vertical" gap="md" className="items-stretch">
-					<ProjectName defaultValue={project.name} onChange={setName} />
-					<ProjectDescription defaultValue={project?.description ?? ""} onChange={setDescription} />
-					<VisibilitySelector defaultValue={project.visibility} onChange={setVisibility} />
-				</Container>
-			</ModalV2.Body>
-			<ModalV2.Footer align="end">
-				<Button variant="secondary">Cancel</Button>
-				<Button variant="danger" onClick={handleDeleteProject}>
-					Delete
-				</Button>
-				<Button onClick={handleUpdateProject} disabled={!canSubmit()}>
-					Update
-				</Button>
-			</ModalV2.Footer>
-		</ModalV2>
+		<>
+			<DeleteProjectModal project={project} />
+			<ModalV2 id={`update-project-modal-${project.id}`} size="lg" loading={isLoading}>
+				<ModalV2.Header title="Update Project" />
+				<ModalV2.Body>
+					<Container direction="vertical" gap="md" className="items-stretch">
+						<ProjectName defaultValue={project.name} onChange={setName} />
+						<ProjectDescription
+							defaultValue={project?.description ?? ""}
+							onChange={setDescription}
+						/>
+						<VisibilitySelector defaultValue={project.visibility} onChange={setVisibility} />
+					</Container>
+				</ModalV2.Body>
+				<ModalV2.Footer align="end">
+					<Button variant="secondary">Cancel</Button>
+					<Button
+						variant="danger"
+						onClick={() => ModalV2.Manager.open(`delete-project-modal-${project.id}`)}
+					>
+						Delete
+					</Button>
+					<Button onClick={handleUpdateProject} disabled={!canSubmit()}>
+						Update
+					</Button>
+				</ModalV2.Footer>
+			</ModalV2>
+		</>
 	);
 }

--- a/src/app/dashboardV2/projectsOverview/ProjectsOverviewV2.tsx
+++ b/src/app/dashboardV2/projectsOverview/ProjectsOverviewV2.tsx
@@ -46,7 +46,7 @@ export default function ProjectsOverviewV2() {
 							))}
 						</Grid>
 					) : isEmpty ? (
-						<NoProjectsView />
+						<NoProjectsView onCreateClick={() => ModalV2.Manager.open("create-project-modal")} />
 					) : null}
 				</Card>
 			</Container>


### PR DESCRIPTION
## Summary

This PR extracts the delete project functionality into a separate `DeleteProjectModal` component with a type-to-confirm safety pattern, improving code organization and user safety.

## Changes

### ✨ New Component: DeleteProjectModal

A dedicated modal component for project deletion with enhanced safety features:

- **Type-to-Confirm Pattern**: Users must type the exact project name to enable the delete button
  - Delete button disabled until typed name matches project name exactly
  - Prevents accidental deletions through intentional confirmation
- **Warning Display**: Red warning box explaining consequences:
  - Permanent deletion warning
  - Details about tasks and member access loss
  - Clear visual indication of destructive action
- **Form Validation**: Real-time validation of confirmation input
- **State Management**: Auto-resets confirmation input on modal close
- **Error Handling**: Proper error handling for delete failures
- **Loading States**: Visual feedback during deletion process

### 🔧 UpdateProjectModal Refactoring

- **Separation of Concerns**: Removed delete logic from update modal
- **Modal Integration**: Delete button now opens `DeleteProjectModal` via `ModalV2.Manager.open()`
- **Cleaner Architecture**: Each modal now has a single, clear responsibility

### 🔗 Integration Improvements

- **NoProjectsView**: Added `onCreateClick` prop for callback flexibility
  - Allows parent component to control create modal opening
  - Maintains component reusability
- **ProjectsOverviewV2**: Wired up empty state create button to open `CreateProjectModal`

## Technical Details

- Uses `ModalV2` system for consistent modal behavior
- Follows V2 component patterns (uncontrolled inputs, clear prop interfaces)
- Leverages RTK Query mutations with automatic cache invalidation
- Modal uniquely identified by `project.id` for multi-project support
- Proper cleanup on modal close via `onAfterClose` callback

## Testing

- ✅ Delete button requires exact project name match
- ✅ Warning box displays correctly
- ✅ Modal opens from UpdateProjectModal delete button
- ✅ Projects list auto-refreshes after successful deletion
- ✅ Error handling works correctly
- ✅ Confirmation input resets on modal close
- ✅ Empty state create button opens CreateProjectModal