### PR TITLE
Add Project Invite System Schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,9 @@ model User {
 
   accounts Account[]
   sessions Session[]
+  
+  sentInvites     Invite[] @relation("Inviter")
+  receivedInvites Invite[] @relation("Invitee")
 
   xp Int @default(0)
 
@@ -111,6 +114,36 @@ enum ProjectVisibility {
   PUBLIC
 }
 
+enum ProjectRole {
+  ADMIN
+  USER
+  VIEWER
+}
+
+model Invite {
+  id            String      @id @default(auto()) @map("_id") @db.ObjectId
+  
+  inviterId     String      @db.ObjectId
+  inviter       User        @relation("Inviter", fields: [inviterId], references: [id], onDelete: Cascade)
+  
+  invitedUserId String      @db.ObjectId
+  invitedUser   User        @relation("Invitee", fields: [invitedUserId], references: [id], onDelete: Cascade)
+  
+  projectId     String      @db.ObjectId
+  project       Project     @relation("ProjectInvites", fields: [projectId], references: [id], onDelete: Cascade)
+  
+  inviteRole    ProjectRole @default(VIEWER)
+  
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
+
+  @@unique([projectId, invitedUserId]) // Prevent duplicate invites
+  @@index([inviterId])
+  @@index([invitedUserId])
+  @@index([projectId])
+  @@index([inviteRole])
+}
+
 model Project {
   id          String            @id @default(auto()) @map("_id") @db.ObjectId
   name        String
@@ -121,12 +154,15 @@ model Project {
   adminUserIds       String[] @default([]) @db.ObjectId // Users with admin access
   projectUserIds     String[] @default([]) @db.ObjectId // Users with standard access
   viewerUserIds      String[] @default([]) @db.ObjectId // Users with read-only access
+  
+  // Join requests and invites
   joinRequestUserIds String[] @default([]) @db.ObjectId // Pending join requests for public projects
+  projectInvites     Invite[] @relation("ProjectInvites") // Invites to the project
 
-  tasks           Task[]
+  tasks              Task[] // Tasks in the project
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
 
   @@index([name])
   @@index([description])


### PR DESCRIPTION
## Add Project Invite System Schema

This PR adds the database schema for the project invite system, enabling admins to invite users to projects and supporting the foundation for an omnidirectional membership management system.

### Changes

- **New `Invite` model** with:
  - Relations to `User` (inviter and invitedUser) with named relations for Prisma
  - Relation to `Project` via `projectInvites`
  - `inviteRole` field to specify the role (ADMIN, USER, VIEWER) the user will receive upon acceptance
  - Unique constraint on `[projectId, invitedUserId]` to prevent duplicate invites
  - Indexes on `inviterId`, `invitedUserId`, `projectId`, and `inviteRole` for query performance

- **New `ProjectRole` enum** with values:
  - `ADMIN` - Full project access
  - `USER` - Standard project access
  - `VIEWER` - Read-only access

- **Updated `User` model**:
  - Added reverse relations (`sentInvites`, `receivedInvites`) required by Prisma for bidirectional relations

- **Updated `Project` model**:
  - Added `projectInvites` relation to track all invites for a project

### Technical Details

The schema is designed to support direct queries on the `Invite` model rather than including invites from User/Project models, optimizing for the following query patterns:
- Fetch sent invites: `prisma.invite.findMany({ where: { inviterId } })`
- Fetch received invites: `prisma.invite.findMany({ where: { invitedUserId } })`
- Fetch project invites: `prisma.invite.findMany({ where: { projectId } })`

### Next Steps

This schema enables implementation of:
- Admin invite functionality
- User invite acceptance/rejection
- Invite management UI
- Automatic role assignment upon invite acceptance