### PR TITLE
Fix: Correct invite filtering and API response format

### DIFF
--- a/src/app/api/projects/[id]/can-invite/route.ts
+++ b/src/app/api/projects/[id]/can-invite/route.ts
@@ -14,7 +14,12 @@ export async function GET(
 		async ({ user, query }) => {
 			const { id } = await params;
 			const inviteRequest = InviteRequestSchema.parse(query);
-			return jsonResponse(canInvite(user.id, inviteRequest.inviteeId, id));
+			const canInviteResult = await canInvite(
+				user.id,
+				inviteRequest.inviteeId,
+				id,
+			);
+			return jsonResponse({ success: canInviteResult });
 		},
 		InviteRequestSchema,
 	);


### PR DESCRIPTION
## 🔧 Fix: Correct invite filtering and API response format

### 🐞 Problem

The invite modal was incorrectly displaying projects where users already had **pending invites**. This happened because:

1. The `can-invite` API returned a raw `boolean` instead of a structured response (`{ success: boolean }`)
2. API errors (such as `403` responses for existing invites) were not handled as “cannot invite”
3. Loading states caused premature empty state displays

---

### ✅ Solution

#### 1. Fixed API response format

Before (returned raw boolean):

    return jsonResponse(
      canInvite(user.id, inviteRequest.inviteeId, id)
    );

After (returns consistent response format):

    const canInviteResult = await canInvite(
      user.id,
      inviteRequest.inviteeId,
      id
    );

    return jsonResponse({ success: canInviteResult });

---

#### 2. Added error state handling

API errors are now treated as **cannot invite**, preventing invalid projects from appearing in the UI:

    const canInvite = isLoading
      ? undefined
      : isError
        ? false // API error = cannot invite
        : (data?.success ?? false);

---

#### 3. Proper loading state management

- Added loading state tracking across all project invite checks
- Prevents premature empty states while queries are still loading
- Displays “No projects available” only after all checks complete

---

### 🔄 Behavior Changes

- **Before:** Projects appeared even when users had pending invites
- **After:** Only projects where invitations are actually possible are displayed

---

### 🧪 Testing

- ✅ Invite modal only shows projects where the user can legitimately be invited
- ✅ Projects are hidden when the user has pending invites, join requests, or is already a member
- ✅ Empty state appears correctly after all loading completes
- ✅ No premature empty states during API calls

---

### 📝 Files Changed

- `src/app/api/projects/[id]/can-invite/route.ts`  
  Fixed API response format
- `src/app/dashboard/modals/invite/InviteModal.tsx`  
  Added error handling and improved loading states

---

### 🎯 Impact

This ensures users never see invalid invite options and prevents failed invite attempts. The invite flow now behaves correctly and predictably, improving clarity and overall user experience.
