### PR TITLE
Feature: Add profile visibility toggle to profile settings

### DIFF
--- a/src/lib/api/users.ts
+++ b/src/lib/api/users.ts
@@ -154,6 +154,7 @@ export async function updateUserProfile(
 		bio?: string | null;
 		location?: string | null;
 		website?: string | null;
+		profileVisibility: "PRIVATE" | "PUBLIC";
 	},
 ): Promise<User> {
 	const updatedUser = await prisma.user.update({
@@ -163,6 +164,7 @@ export async function updateUserProfile(
 			bio: profileData.bio,
 			location: profileData.location,
 			website: profileData.website,
+			profileVisibility: profileData.profileVisibility,
 		},
 		select: {
 			id: true,

--- a/src/lib/validation/users-schema.ts
+++ b/src/lib/validation/users-schema.ts
@@ -8,7 +8,6 @@ export const UserSchema = z.object({
 	profileVisibility: z.string().nullable(),
 	xp: z.number(),
 	emailVerified: z.boolean().nullable(),
-	// New profile fields
 	displayName: z.string().min(1).max(50), // Required, 1-50 chars
 	bio: z.string().max(500).nullable(), // Optional, max 500 chars
 	location: z.string().max(100).nullable(), // Optional, max 100 chars
@@ -26,6 +25,7 @@ export const UpdateUserProfileSchema = z.object({
 	bio: z.string().max(500).nullable(),
 	location: z.string().max(100).nullable(),
 	website: z.string().url().nullable().or(z.literal("")),
+	profileVisibility: z.enum(["PRIVATE", "PUBLIC"]),
 });
 
 export const UpdateUserProfileResponseSchema = z.object({


### PR DESCRIPTION
## 🎯 **Profile Visibility Toggle in Settings**

This PR adds the ability for users to toggle their profile visibility (PUBLIC/PRIVATE) directly from the profile settings page, giving users full control over their privacy settings.

## 📋 **What's New**

### **Profile Visibility Control**
- **Interactive Toggle**: Users can switch between PUBLIC and PRIVATE profile visibility
- **Visual Feedback**: Purple toggle indicator when PUBLIC, gray when PRIVATE
- **Immediate Effect**: Changes take effect immediately and affect search discoverability
- **Persistent Settings**: Profile visibility is saved to database and maintained across sessions

### **Enhanced User Experience**
- **Settings Integration**: Privacy control integrated into existing profile settings UI
- **Real-time Updates**: No page refresh needed - changes apply instantly
- **State Persistence**: Toggle reflects current database state on page load
- **Clear Labeling**: "Public Profile" section clearly indicates the functionality

## 🔧 **Technical Implementation**

### **Database & API**
- Added `profileVisibility` field to `UpdateUserProfileSchema` with enum validation (`"PRIVATE" | "PUBLIC"`)
- Extended `updateUserProfile()` API function to handle visibility updates
- Prisma update operations now include profile visibility changes

### **Frontend Architecture**
- **Controlled Component**: Profile visibility toggle is now a controlled React component
- **State Management**: Added `profileVisibility` state to ProfileSettings component
- **Form Integration**: Visibility toggle included in profile update submissions
- **Type Safety**: Proper TypeScript typing for visibility enum values
