### PR TITLE
Remove dead tar override and document remaining dependency overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,12 +79,20 @@
 		"overrides": {
 			"preact": ">=10.28.2",
 			"qs": ">=6.14.2",
-			"tar": ">=7.5.7",
 			"ajv": ">=8.18.0",
 			"minimatch": ">=10.2.3",
 			"hono": ">=4.12.7",
 			"express-rate-limit": ">=8.2.2",
 			"effect": ">=3.20.0"
+		},
+		"overrideComments": {
+			"preact": "next-auth v4 / @auth/prisma-adapter → @auth/core. Resolves with next-auth v5 (Auth.js) migration.",
+			"qs": "@google/genai → @modelcontextprotocol/sdk → express. Resolves with upstream SDK update.",
+			"ajv": "@google/genai → @modelcontextprotocol/sdk → ajv-formats. Resolves with upstream SDK update.",
+			"minimatch": "@google/genai → google-auth-library → gaxios → rimraf → glob; ertk → ts-morph. Resolves with upstream updates.",
+			"hono": "@google/genai → @modelcontextprotocol/sdk → @hono/node-server. Resolves with upstream SDK update.",
+			"express-rate-limit": "@google/genai → @modelcontextprotocol/sdk. Resolves with upstream SDK update.",
+			"effect": "prisma → @prisma/config; uploadthing → @effect/platform. Resolves with upstream updates."
 		},
 		"ignoredBuiltDependencies": [
 			"@biomejs/biome",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,6 @@ settings:
 overrides:
   preact: '>=10.28.2'
   qs: '>=6.14.2'
-  tar: '>=7.5.7'
   ajv: '>=8.18.0'
   minimatch: '>=10.2.3'
   hono: '>=4.12.7'


### PR DESCRIPTION
## Summary
  - Remove the `tar` override — no dependency chain pulls it in and `pnpm audit` remains
  clean without it
  - Add `pnpm.overrideComments` documenting the root cause of each remaining override and
  what upstream update resolves it:
    - `preact`: next-auth v4 → resolves with Auth.js migration
    - `qs`, `ajv`, `hono`, `express-rate-limit`, `minimatch`: @google/genai → resolves with
  upstream SDK updates
    - `effect`: prisma + uploadthing → resolves with upstream updates

  Addresses audit item 2.18.

  ## Test plan
  - [x] `pnpm install` succeeds
  - [x] `pnpm audit` reports no vulnerabilities
  - [x] Build passes