### PR TITLE
Complete remember me feature with per-session expiry enforcement

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -11,6 +11,12 @@ import GoogleProvider from "next-auth/providers/google";
 
 const prismaAdapter = PrismaAdapter(prisma) as Adapter;
 
+/** Duration for "remembered" sessions (14 days in seconds). */
+const REMEMBERED_MAX_AGE = 14 * 24 * 60 * 60;
+
+/** Duration for "non-remembered" sessions (24 hours in seconds). */
+const SHORT_MAX_AGE = 24 * 60 * 60;
+
 export const authOptions: NextAuthOptions = {
 	adapter: {
 		...prismaAdapter,
@@ -43,6 +49,7 @@ export const authOptions: NextAuthOptions = {
 			credentials: {
 				email: { label: "Email", type: "email" },
 				password: { label: "Password", type: "password" },
+				remember: { label: "Remember me", type: "text" },
 			},
 			async authorize(credentials) {
 				if (!credentials?.email || !credentials.password) return null;
@@ -73,6 +80,7 @@ export const authOptions: NextAuthOptions = {
 					email: user.email,
 					image: user.image,
 					twoFactorEnabled: user.twoFactorEnabled,
+					rememberMe: credentials.remember === "true",
 				};
 			},
 		}),
@@ -80,7 +88,7 @@ export const authOptions: NextAuthOptions = {
 
 	session: {
 		strategy: "jwt",
-		maxAge: 30 * 24 * 60 * 60, // 30 days
+		maxAge: REMEMBERED_MAX_AGE, // 14 days
 		updateAge: 24 * 60 * 60, // refresh every 24h
 	},
 
@@ -133,6 +141,12 @@ export const authOptions: NextAuthOptions = {
 				// Generate a unique JWT ID for device session tracking
 				token.jti = crypto.randomUUID();
 
+				// Set custom session expiry based on "remember me" preference.
+				// OAuth sign-ins have undefined rememberMe, defaulting to remembered.
+				const rememberMe = user.rememberMe !== false;
+				const maxAge = rememberMe ? REMEMBERED_MAX_AGE : SHORT_MAX_AGE;
+				token.expiresAt = Date.now() + maxAge * 1000;
+
 				// Pre-register device session so API calls succeed immediately
 				// on the first page load (avoids race with DeviceSessionProvider).
 				// DeviceSessionProvider will upsert with device info later.
@@ -159,6 +173,16 @@ export const authOptions: NextAuthOptions = {
 				}
 			}
 
+			// Enforce custom session expiry (short "non-remembered" sessions)
+			if (token.expiresAt && Date.now() >= token.expiresAt) {
+				if (token.jti) {
+					await prisma.deviceSession
+						.delete({ where: { jti: token.jti as string } })
+						.catch(() => {});
+				}
+				return {} as typeof token;
+			}
+
 			// Handle session.update() trigger for 2FA verification
 			if (trigger === "update" && token.id && token.pendingTwoFactor) {
 				const dbUser = await prisma.user.findUnique({
@@ -177,9 +201,6 @@ export const authOptions: NextAuthOptions = {
 				}
 			}
 
-			if (token.shortSession) {
-				token.shortSession = true;
-			}
 			return token;
 		},
 
@@ -193,9 +214,11 @@ export const authOptions: NextAuthOptions = {
 			if (token.pendingTwoFactor) {
 				session.pendingTwoFactor = true;
 			}
-			if (token.shortSession) {
-				session.remember = false;
+			if (token.expiresAt) {
+				session.expiresAt = token.expiresAt;
 			}
+			session.remember =
+				!token.expiresAt || token.expiresAt - Date.now() > SHORT_MAX_AGE * 1000;
 			return session;
 		},
 	},

--- a/src/lib/ertk-handler.ts
+++ b/src/lib/ertk-handler.ts
@@ -19,6 +19,9 @@ export const createRouteHandler = configureHandler({
 			const email = session?.user?.email;
 			if (!email) return null;
 
+			// Check custom session expiry
+			if (session.expiresAt && Date.now() >= session.expiresAt) return null;
+
 			// Check if session is pending 2FA — block API access
 			if (session.pendingTwoFactor) return null;
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -23,6 +23,24 @@ export async function proxy(request: NextRequest) {
 		return NextResponse.redirect(loginUrl);
 	}
 
+	// Enforce custom session expiry (short "non-remembered" sessions).
+	// Cookie deletion prevents redirect loops with the expired JWT.
+	if (
+		token?.expiresAt &&
+		typeof token.expiresAt === "number" &&
+		Date.now() >= token.expiresAt &&
+		!isPublicRoute
+	) {
+		const loginUrl = new URL("/", request.url);
+		const response = NextResponse.redirect(loginUrl);
+		const cookieName =
+			process.env.NODE_ENV === "production"
+				? "__Secure-next-auth.session-token"
+				: "next-auth.session-token";
+		response.cookies.delete(cookieName);
+		return response;
+	}
+
 	// If user has pending 2FA and is trying to access protected routes,
 	// redirect them to the 2FA page
 	if (token?.pendingTwoFactor && !isPublicRoute) {

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,11 +1,16 @@
 import type { DefaultJWT, DefaultSession } from "next-auth";
 
 declare module "next-auth" {
+	interface User {
+		rememberMe?: boolean;
+	}
+
 	interface Session extends DefaultSession {
 		user?: {
 			id?: string;
 		} & DefaultSession["user"];
 		remember?: boolean;
+		expiresAt?: number;
 		jti?: string;
 		pendingTwoFactor?: boolean;
 	}
@@ -14,7 +19,7 @@ declare module "next-auth" {
 declare module "next-auth/jwt" {
 	interface JWT extends DefaultJWT {
 		id?: string;
-		shortSession?: boolean;
+		expiresAt?: number;
 		jti?: string;
 		pendingTwoFactor?: boolean;
 	}


### PR DESCRIPTION
## Summary
  - Wire up the existing "Remember me" checkbox to control JWT session duration — unchecked:
   24 hours, checked: 14 days
  - OAuth sign-ins (Google/GitHub) default to the 14-day remembered duration
  - Reduce global session `maxAge` from 30 → 14 days
  - Enforce custom `expiresAt` timestamp at three layers to work around NextAuth v4's single
   global `maxAge`:
    - **JWT callback**: invalidates token and cleans up device session on expiry
    - **Proxy**: redirects to login and deletes session cookie (prevents redirect loops)
    - **ERTK handler**: returns 401 for API calls with expired sessions
  - Remove dead `shortSession` code that was never wired up
  - Legacy tokens (without `expiresAt`) are gracefully handled — they use the new 14-day
  global maxAge

  Addresses audit item 2.20.

  ## Test plan
  - [x] Sign in with "Remember me" unchecked → verify short session (set `SHORT_MAX_AGE` to
  60s temporarily to test expiry behavior)
  - [x] Sign in with "Remember me" checked → verify 14-day `expiresAt` in JWT
  - [x] Sign in via Google/GitHub OAuth → verify 14-day `expiresAt` (no checkbox, defaults
  to remembered)
  - [x] After short session expires: page navigation redirects to login, API calls return
  401
  - [x] Existing sessions continue working (legacy tokens without `expiresAt` are
  unaffected)
  - [x] 2FA flow works correctly with both remembered and non-remembered sessions
  - [x] `pnpm build` passes