### PR TITLE
security: replace static CSP with per-request nonce in proxy

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,21 +2,8 @@ import type { NextConfig } from "next";
 
 const isProd = process.env.NODE_ENV === "production";
 
-const cspDirectives = [
-	"default-src 'self'",
-	"script-src 'self' 'unsafe-inline' 'unsafe-eval'",
-	"style-src 'self' 'unsafe-inline'",
-	"img-src 'self' blob: data: https://lh3.googleusercontent.com https://utfs.io https://*.utfs.io https://ufs.sh https://*.ufs.sh",
-	"font-src 'self'",
-	"connect-src 'self' https://realtime.ably.io https://rest.ably.io https://*.ably.io https://*.ably.net wss://realtime.ably.io wss://*.ably.io wss://*.ably.net https://ingest.uploadthing.com https://*.uploadthing.com",
-	"worker-src 'self'",
-	"frame-ancestors 'none'",
-	"form-action 'self'",
-	"base-uri 'self'",
-	"object-src 'none'",
-	"upgrade-insecure-requests",
-];
-
+// CSP is handled per-request via nonce in src/middleware.ts.
+// Only static security headers remain here.
 const securityHeaders = [
 	{ key: "X-Frame-Options", value: "DENY" },
 	{ key: "X-Content-Type-Options", value: "nosniff" },
@@ -27,10 +14,6 @@ const securityHeaders = [
 	},
 	...(isProd
 		? [
-				{
-					key: "Content-Security-Policy",
-					value: cspDirectives.join("; "),
-				},
 				{
 					key: "Strict-Transport-Security",
 					value: "max-age=63072000; includeSubDomains; preload",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import "@pointwise/lib/env";
 import { NextSSRPlugin } from "@uploadthing/react/next-ssr-plugin";
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { headers } from "next/headers";
 import { extractRouterConfig } from "uploadthing/server";
 import { ourFileRouter } from "./api/uploadthing/core";
 import "./globals.css";
@@ -81,11 +82,15 @@ export const viewport: Viewport = {
 	themeColor: "#3B0270",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
 	children,
 }: Readonly<{
 	children: React.ReactNode;
 }>) {
+	// Reading the nonce header triggers Next.js to attach it to
+	// framework-generated inline <script> tags (required for nonce-based CSP).
+	(await headers()).get("x-nonce");
+
 	return (
 		<html lang="en">
 			<body

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,7 +2,48 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { getToken } from "next-auth/jwt";
 
+const isProd = process.env.NODE_ENV === "production";
+
+function buildCsp(nonce: string): string {
+	// unsafe-eval required in dev only (React 19 dev error stacks + HMR)
+	const scriptSrc = isProd
+		? `'self' 'nonce-${nonce}' 'strict-dynamic'`
+		: `'self' 'nonce-${nonce}' 'strict-dynamic' 'unsafe-eval'`;
+
+	// style-src keeps unsafe-inline: next/image injects style="color:transparent"
+	// which cannot receive a nonce. Tracked: https://github.com/vercel/next.js/issues/61388
+	return [
+		"default-src 'self'",
+		`script-src ${scriptSrc}`,
+		"style-src 'self' 'unsafe-inline'",
+		"img-src 'self' blob: data: https://lh3.googleusercontent.com https://utfs.io https://*.utfs.io https://ufs.sh https://*.ufs.sh",
+		"font-src 'self'",
+		"connect-src 'self' https://realtime.ably.io https://rest.ably.io https://*.ably.io https://*.ably.net wss://realtime.ably.io wss://*.ably.io wss://*.ably.net https://ingest.uploadthing.com https://*.uploadthing.com",
+		"worker-src 'self'",
+		"frame-ancestors 'none'",
+		"form-action 'self'",
+		"base-uri 'self'",
+		"object-src 'none'",
+		...(isProd ? ["upgrade-insecure-requests"] : []),
+	].join("; ");
+}
+
+/** Apply CSP nonce header to any response (including redirects). */
+function applyCspHeader(response: NextResponse, csp: string): NextResponse {
+	response.headers.set("Content-Security-Policy", csp);
+	return response;
+}
+
 export async function proxy(request: NextRequest) {
+	// --- CSP nonce ---
+	const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+	const csp = buildCsp(nonce);
+
+	const requestHeaders = new Headers(request.headers);
+	requestHeaders.set("x-nonce", nonce);
+	requestHeaders.set("Content-Security-Policy", csp);
+
+	// --- Auth ---
 	const token = await getToken({
 		req: request,
 		secret: process.env.NEXTAUTH_SECRET,
@@ -20,7 +61,7 @@ export async function proxy(request: NextRequest) {
 	// Redirect unauthenticated users to landing page for protected routes
 	if (!token && !isPublicRoute) {
 		const loginUrl = new URL("/", request.url);
-		return NextResponse.redirect(loginUrl);
+		return applyCspHeader(NextResponse.redirect(loginUrl), csp);
 	}
 
 	// Enforce custom session expiry (short "non-remembered" sessions).
@@ -38,17 +79,18 @@ export async function proxy(request: NextRequest) {
 				? "__Secure-next-auth.session-token"
 				: "next-auth.session-token";
 		response.cookies.delete(cookieName);
-		return response;
+		return applyCspHeader(response, csp);
 	}
 
 	// If user has pending 2FA and is trying to access protected routes,
 	// redirect them to the 2FA page
 	if (token?.pendingTwoFactor && !isPublicRoute) {
 		const twoFactorUrl = new URL("/two-factor", request.url);
-		return NextResponse.redirect(twoFactorUrl);
+		return applyCspHeader(NextResponse.redirect(twoFactorUrl), csp);
 	}
 
-	return NextResponse.next();
+	const response = NextResponse.next({ request: { headers: requestHeaders } });
+	return applyCspHeader(response, csp);
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
  - Move CSP from static `next.config.ts` headers to dynamic per-request generation in `src/proxy.ts` using a cryptographic nonce
  - Eliminate `'unsafe-inline'` and `'unsafe-eval'` from `script-src` in production (`'unsafe-eval'` kept in dev only for React 19 error stacks + HMR)
  - Read nonce via `headers()` in root layout so Next.js propagates it to framework-generated inline `<script>` tags
  - `style-src` retains `'unsafe-inline'` pending upstream fix for `next/image` inline styles (vercel/next.js#61388)

  ## Test plan
  - [x] Dev server starts without CSP console errors
  - [x] Production build: inspect response headers and confirm `script-src` contains `'nonce-...' 'strict-dynamic'` with no `'unsafe-inline'` or `'unsafe-eval'`
  - [x] Auth redirects (unauthed, expired session, pending 2FA) still include the CSP header
  - [x] No script-blocked errors in browser console on dashboard, analytics, profile, and messaging pages