### PR TITLE
Discrete-task constraint to AI generation prompts

### DIFF
--- a/src/lib/api/task-generation.ts
+++ b/src/lib/api/task-generation.ts
@@ -27,6 +27,10 @@ export function buildTaskSuggestionsPrompt(
 Suggest exactly 3 new tasks for the project described below.
 Each suggestion should be distinct from existing tasks and from each other.
 
+Each task must be a discrete, one-time action that can be completed in a single session.
+Do NOT suggest tasks that require daily repetition, streaks, or sustained effort over multiple days (e.g. "exercise for 7 days straight", "read every morning for a week").
+Instead, suggest concrete, completable actions (e.g. "complete a 30-minute workout", "read chapter 3 of [book]").
+
 Output ONLY a JSON array with exactly 3 objects, each having "title" and "summary" keys.
 - "title": A concise task title (3-10 words)
 - "summary": A 1-2 sentence description of what the task involves
@@ -94,6 +98,8 @@ export function buildTaskExpansionPrompt(
 	return `You are a task planner for a project management app.
 
 Expand the following task suggestion into a full task definition.
+The task must describe a discrete, one-time action — not a recurring habit or multi-day streak.
+Frame the task as something that can be marked complete after a single effort.
 
 Output ONLY a JSON object with these keys:
 - "title": The task title (may refine the original, 3-10 words)


### PR DESCRIPTION
## Summary
  - Updated AI task suggestion and expansion prompts to explicitly prohibit repetitive/streak-based tasks (e.g. "exercise for 7 days straight")
  - Tasks must now be discrete, one-time actions completable in a single session

  ## Test plan
  - [x] Generate tasks with a goal like "improve my fitness" and verify suggestions are concrete one-time actions, not daily streaks
  - [x] Expand a suggested task and confirm the description frames it as a single completable effort