### PR TITLE
Instrument AI calls with token usage tracking

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,6 +81,9 @@ model User {
   comments     Comment[]
   commentLikes CommentLike[]
 
+  aiUsageTriggered AiUsageEvent[] @relation("AiUsageTriggered")
+  aiUsageBilled    AiUsageEvent[] @relation("AiUsageBilled")
+
   deviceSessions      DeviceSession[]
   webAuthnCredentials WebAuthnCredential[]
 
@@ -243,6 +246,38 @@ enum ProjectRole {
   ADMIN
   USER
   VIEWER
+}
+
+enum AiActionType {
+  TASK_SUGGESTIONS
+  TASK_EXPAND
+  TASK_BREAKDOWN
+  XP_SUGGESTION
+}
+
+model AiUsageEvent {
+  id             String       @id @default(auto()) @map("_id") @db.ObjectId
+  userId         String       @db.ObjectId
+  user           User         @relation("AiUsageTriggered", fields: [userId], references: [id], onDelete: Cascade)
+  billedUserId   String       @db.ObjectId
+  billedUser     User         @relation("AiUsageBilled", fields: [billedUserId], references: [id], onDelete: Cascade)
+  projectId      String?      @db.ObjectId
+  actionType     AiActionType
+  model          String
+  inputTokens    Int
+  outputTokens   Int
+  costUsd        Float
+  creditsCharged Int
+  success        Boolean
+  durationMs     Int
+  createdAt      DateTime     @default(now())
+
+  @@index([userId])
+  @@index([billedUserId])
+  @@index([billedUserId, createdAt])
+  @@index([projectId])
+  @@index([createdAt])
+  @@index([actionType])
 }
 
 model Invite {

--- a/src/endpoints/llm/task-breakdown.ts
+++ b/src/endpoints/llm/task-breakdown.ts
@@ -11,11 +11,13 @@ export default endpoint.post<TaskBreakdownResponse, TaskBreakdownRequest>({
 	request: TaskBreakdownRequestSchema,
 	protected: true,
 	query: (body) => ({ url: "/llm/task-breakdown", method: "POST", body }),
-	handler: async ({ body }) => {
+	handler: async ({ body, user }) => {
 		const subtasks = await getTaskBreakdown(
 			body.goal ?? null,
 			body.title.trim(),
 			body.description?.trim() ?? null,
+			user.id,
+			body.projectId,
 		);
 
 		if (subtasks === null) {

--- a/src/endpoints/llm/task-expand.ts
+++ b/src/endpoints/llm/task-expand.ts
@@ -11,11 +11,13 @@ export default endpoint.post<TaskExpandResponse, TaskExpandRequest>({
 	request: TaskExpandRequestSchema,
 	protected: true,
 	query: (body) => ({ url: "/llm/task-expand", method: "POST", body }),
-	handler: async ({ body }) => {
+	handler: async ({ body, user }) => {
 		const expanded = await expandTaskSuggestion(
 			body.goal ?? null,
 			body.title.trim(),
 			body.summary.trim(),
+			user.id,
+			body.projectId,
 		);
 
 		if (expanded === null) {

--- a/src/endpoints/llm/task-suggestions.ts
+++ b/src/endpoints/llm/task-suggestions.ts
@@ -11,11 +11,13 @@ export default endpoint.post<TaskSuggestionsResponse, TaskSuggestionsRequest>({
 	request: TaskSuggestionsRequestSchema,
 	protected: true,
 	query: (body) => ({ url: "/llm/task-suggestions", method: "POST", body }),
-	handler: async ({ body }) => {
+	handler: async ({ body, user }) => {
 		const suggestions = await getTaskSuggestions(
 			body.goal ?? null,
 			body.existingTasks ?? [],
 			body.userPrompt?.trim() ?? null,
+			user.id,
+			body.projectId,
 		);
 
 		if (suggestions === null) {

--- a/src/endpoints/llm/xp-suggestion.ts
+++ b/src/endpoints/llm/xp-suggestion.ts
@@ -8,11 +8,12 @@ export default endpoint.post<{ xp: number }, XpSuggestionRequest>({
 	request: XpSuggestionRequestSchema,
 	protected: true,
 	query: (body) => ({ url: "/llm/xp-suggestion", method: "POST", body }),
-	handler: async ({ body }) => {
+	handler: async ({ body, user }) => {
 		const xp = await getXpSuggestion(
 			body.goal ?? null,
 			body.taskName.trim(),
 			body.description?.trim() ?? null,
+			user.id,
 		);
 
 		if (xp === null) {

--- a/src/lib/api/task-generation.ts
+++ b/src/lib/api/task-generation.ts
@@ -80,9 +80,15 @@ export async function getTaskSuggestions(
 	goal: string | null,
 	existingTasks: ExistingTask[],
 	userPrompt: string | null,
+	userId: string,
+	projectId: string,
 ): Promise<TaskSuggestion[] | null> {
 	const prompt = buildTaskSuggestionsPrompt(goal, existingTasks, userPrompt);
-	const { success, response } = await callGemini(prompt);
+	const { success, response } = await callGemini(prompt, {
+		userId,
+		projectId,
+		actionType: "TASK_SUGGESTIONS",
+	});
 	if (!success || !response) return null;
 	return parseSuggestionsFromResponse(response);
 }
@@ -148,9 +154,15 @@ export async function expandTaskSuggestion(
 	goal: string | null,
 	title: string,
 	summary: string,
+	userId: string,
+	projectId: string,
 ): Promise<TaskExpandResponse | null> {
 	const prompt = buildTaskExpansionPrompt(goal, title, summary);
-	const { success, response } = await callGemini(prompt);
+	const { success, response } = await callGemini(prompt, {
+		userId,
+		projectId,
+		actionType: "TASK_EXPAND",
+	});
 	if (!success || !response) return null;
 	return parseExpandFromResponse(response);
 }
@@ -225,9 +237,15 @@ export async function getTaskBreakdown(
 	goal: string | null,
 	title: string,
 	description: string | null,
+	userId: string,
+	projectId: string,
 ): Promise<TaskBreakdownSubtask[] | null> {
 	const prompt = buildTaskBreakdownPrompt(goal, title, description);
-	const { success, response } = await callGemini(prompt);
+	const { success, response } = await callGemini(prompt, {
+		userId,
+		projectId,
+		actionType: "TASK_BREAKDOWN",
+	});
 	if (!success || !response) return null;
 	return parseBreakdownFromResponse(response);
 }

--- a/src/lib/api/xp.ts
+++ b/src/lib/api/xp.ts
@@ -123,9 +123,13 @@ export async function getXpSuggestion(
 	goal: string | null,
 	taskName: string,
 	description: string | null,
+	userId: string,
 ): Promise<number | null> {
 	const prompt = buildXpSuggestionPrompt(goal, taskName, description);
-	const { success, response } = await callGemini(prompt);
+	const { success, response } = await callGemini(prompt, {
+		userId,
+		actionType: "XP_SUGGESTION",
+	});
 	if (!success || !response) return null;
 	return parseXpFromResponse(response);
 }

--- a/src/lib/llm/cost.ts
+++ b/src/lib/llm/cost.ts
@@ -1,0 +1,17 @@
+const PRICING: Record<string, { inputPer1M: number; outputPer1M: number }> = {
+	"gemini-3-flash-preview": { inputPer1M: 0.5, outputPer1M: 3.0 },
+	"gemini-2.5-flash": { inputPer1M: 0.3, outputPer1M: 2.5 },
+};
+
+const DEFAULT_MODEL = "gemini-3-flash-preview";
+
+export function calculateCostUsd(
+	model: string,
+	inputTokens: number,
+	outputTokens: number,
+): number {
+	const p = PRICING[model] ?? PRICING[DEFAULT_MODEL];
+	return (
+		(inputTokens * p.inputPer1M + outputTokens * p.outputPer1M) / 1_000_000
+	);
+}

--- a/src/lib/llm/gemini.ts
+++ b/src/lib/llm/gemini.ts
@@ -4,14 +4,31 @@
  */
 
 import { GoogleGenAI } from "@google/genai";
+import { calculateCostUsd } from "@pointwise/lib/llm/cost";
+import prisma from "@pointwise/lib/prisma";
+import type { AiActionType } from "@prisma/client";
 
-const MODEL = "gemini-3-flash-preview";
+export const MODEL = "gemini-3-flash-preview";
 const TIMEOUT_MS = 60_000;
 
-export async function callGemini(prompt: string): Promise<{
+interface UsageContext {
+	userId: string;
+	projectId?: string;
+	actionType: AiActionType;
+}
+
+export async function callGemini(
+	prompt: string,
+	usageContext?: UsageContext,
+): Promise<{
 	success: boolean;
 	response?: string;
 	error?: string;
+	usage?: {
+		inputTokens: number;
+		outputTokens: number;
+		totalTokens: number;
+	};
 }> {
 	const apiKey = process.env.GEMINI_API_KEY?.trim();
 	if (!apiKey) {
@@ -23,6 +40,7 @@ export async function callGemini(prompt: string): Promise<{
 	}
 
 	const ai = new GoogleGenAI({ apiKey });
+	const start = performance.now();
 
 	try {
 		const response = await Promise.race([
@@ -34,7 +52,61 @@ export async function callGemini(prompt: string): Promise<{
 
 		const text = response.text;
 		if (typeof text === "string" && text.length > 0) {
-			return { success: true, response: text };
+			const meta = response.usageMetadata;
+			const usage =
+				meta?.promptTokenCount != null &&
+				meta?.candidatesTokenCount != null &&
+				meta?.totalTokenCount != null
+					? {
+							inputTokens: meta.promptTokenCount,
+							outputTokens: meta.candidatesTokenCount,
+							totalTokens: meta.totalTokenCount,
+						}
+					: undefined;
+
+			if (usageContext) {
+				const inputTokens = usage?.inputTokens ?? 0;
+				const outputTokens = usage?.outputTokens ?? 0;
+				prisma.aiUsageEvent
+					.create({
+						data: {
+							userId: usageContext.userId,
+							billedUserId: usageContext.userId,
+							projectId: usageContext.projectId,
+							actionType: usageContext.actionType,
+							model: MODEL,
+							inputTokens,
+							outputTokens,
+							costUsd: calculateCostUsd(MODEL, inputTokens, outputTokens),
+							creditsCharged: 0,
+							success: true,
+							durationMs: Math.round(performance.now() - start),
+						},
+					})
+					.catch(() => {});
+			}
+
+			return { success: true, response: text, usage };
+		}
+
+		if (usageContext) {
+			prisma.aiUsageEvent
+				.create({
+					data: {
+						userId: usageContext.userId,
+						billedUserId: usageContext.userId,
+						projectId: usageContext.projectId,
+						actionType: usageContext.actionType,
+						model: MODEL,
+						inputTokens: 0,
+						outputTokens: 0,
+						costUsd: 0,
+						creditsCharged: 0,
+						success: false,
+						durationMs: Math.round(performance.now() - start),
+					},
+				})
+				.catch(() => {});
 		}
 
 		return {
@@ -42,6 +114,26 @@ export async function callGemini(prompt: string): Promise<{
 			error: "Gemini returned empty response",
 		};
 	} catch (err) {
+		if (usageContext) {
+			prisma.aiUsageEvent
+				.create({
+					data: {
+						userId: usageContext.userId,
+						billedUserId: usageContext.userId,
+						projectId: usageContext.projectId,
+						actionType: usageContext.actionType,
+						model: MODEL,
+						inputTokens: 0,
+						outputTokens: 0,
+						costUsd: 0,
+						creditsCharged: 0,
+						success: false,
+						durationMs: Math.round(performance.now() - start),
+					},
+				})
+				.catch(() => {});
+		}
+
 		const message = err instanceof Error ? err.message : "Request failed";
 		return { success: false, error: message };
 	}


### PR DESCRIPTION
## Summary

  - **1.1** — `callGemini()` now extracts `usageMetadata` from the Gemini SDK response and returns `usage?: { inputTokens, outputTokens, totalTokens }`
  - **1.2** — Added `AiActionType` enum and `AiUsageEvent` model to the Prisma schema with indexes on `userId`, `billedUserId`, `projectId`, `createdAt`, and `actionType`
  - **1.3** — Added `calculateCostUsd()` utility in `src/lib/llm/cost.ts` with pricing for `gemini-3-flash-preview` and `gemini-2.5-flash`
  - **1.4** — `callGemini()` accepts an optional `UsageContext` and automatically logs an `AiUsageEvent` (fire-and-forget) on every call — success or failure

  ## Details

  All four AI endpoints now pass user/project context through to `callGemini()`:
  - `POST /api/llm/task-suggestions` → `TASK_SUGGESTIONS`
  - `POST /api/llm/task-expand` → `TASK_EXPAND`
  - `POST /api/llm/task-breakdown` → `TASK_BREAKDOWN`
  - `POST /api/llm/xp-suggestion` → `XP_SUGGESTION`

  `billedUserId` = `userId` and `creditsCharged` = `0` for now — these become meaningful in Phase 4 (credit gating).

  ## Test plan

  - [x] `pnpm prisma db push` to create the `AiUsageEvent` collection
  - [x] Trigger each AI feature in the app
  - [x] Open Prisma Studio and verify `AiUsageEvent` records have realistic token counts, non-zero `costUsd`, and correct `actionType`
  - [x] Verify a failed call (e.g. invalid API key) logs with `success: false`